### PR TITLE
Update `acktest` and rename `TestBootstrapResources`

### DIFF
--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -22,15 +22,15 @@ from acktest.bootstrapping.vpc import VPC
 from e2e import bootstrap_directory
 
 @dataclass
-class TestBootstrapResources(Resources):
+class BootstrapResources(Resources):
     ClusterVPC: VPC
     ClusterRole: Role
     FargatePodRole: Role
 
 _bootstrap_resources = None
 
-def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.pkl") -> TestBootstrapResources:
+def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.pkl") -> BootstrapResources:
     global _bootstrap_resources
     if _bootstrap_resources is None:
-        _bootstrap_resources = TestBootstrapResources.deseralize(bootstrap_directory, bootstrap_file_name=bootstrap_file_name)
+        _bootstrap_resources = BootstrapResources.deserialize(bootstrap_directory, bootstrap_file_name=bootstrap_file_name)
     return _bootstrap_resources

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@955d7831ee374a212250179e95a5f3b75e555fd9
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@8b21fd1a3374f506d35efe7426d5deed8b1bb1bf

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -18,14 +18,12 @@ from acktest.bootstrapping import Resources, BootstrapFailureException
 from acktest.bootstrapping.iam import Role
 from acktest.bootstrapping.vpc import VPC
 from e2e import bootstrap_directory
-from e2e.bootstrap_resources import (
-    TestBootstrapResources,
-)
+from e2e.bootstrap_resources import BootstrapResources
 
 def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
     
-    resources = TestBootstrapResources(
+    resources = BootstrapResources(
         ClusterRole=Role("cluster-role", "eks.amazonaws.com", ["arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"]),
         FargatePodRole=Role("fargate-pod-role", "eks-fargate-pods.amazonaws.com", ["arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"]),
         ClusterVPC=VPC(name_prefix="cluster-vpc", num_public_subnet=2, num_private_subnet=2)

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -23,7 +23,7 @@ from e2e import bootstrap_directory
 def service_cleanup():
     logging.getLogger().setLevel(logging.INFO)
 
-    resources = Resources.deseralize(bootstrap_directory)
+    resources = Resources.deserialize(bootstrap_directory)
     resources.cleanup()
 
 if __name__ == "__main__":   


### PR DESCRIPTION
Description of changes:
- Updated `acktest` to remove typo in `deserialize`
- Renamed `TestBootstrapResources` to `BootstrapResources` so `pytest` will stop complaining that it's not a test class

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
