### PR TITLE
Add resource references to cluster names

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-01-12T04:50:40Z"
-  build_hash: c7b19a3ec651b287477e7330d0ea1c725a904310
+  build_date: "2022-01-12T20:00:52Z"
+  build_hash: b24c062600f1ae90d62e760c23e69651ac167a24
   go_version: go1.17.1
   version: v0.16.0
-api_directory_checksum: 88e8190538f9fed78cb11c57b9053ee907ef0233
+api_directory_checksum: aca79dadb322fdb182185a7e9b9cb44e14b30d0a
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.67
 generator_config_info:
-  file_checksum: 5371286fde1bbec2473f4788d646cc62c0b3a6d4
+  file_checksum: 794a511b629b00b81bfe943eaf41eedf7c780ff7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-01-09T00:30:18Z"
-  build_hash: 3e184727de8a4dfd4769e3d88f4f52f885858335
+  build_date: "2022-01-12T04:50:40Z"
+  build_hash: c7b19a3ec651b287477e7330d0ea1c725a904310
   go_version: go1.17.1
   version: v0.16.0
-api_directory_checksum: 18423a5aa90c547e267c460f25ce08e5c0b4aaa6
+api_directory_checksum: 88e8190538f9fed78cb11c57b9053ee907ef0233
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.67
 generator_config_info:
-  file_checksum: b66d077bc28c12a65378f3eb515c5ab814a93090
+  file_checksum: 5371286fde1bbec2473f4788d646cc62c0b3a6d4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/addon.go
+++ b/apis/v1alpha1/addon.go
@@ -31,8 +31,8 @@ type AddonSpec struct {
 	// of the request.
 	ClientRequestToken *string `json:"clientRequestToken,omitempty"`
 	// The name of the cluster to create the add-on for.
-	// +kubebuilder:validation:Required
-	ClusterName *string `json:"clusterName"`
+	ClusterName    *string                                  `json:"clusterName,omitempty"`
+	ClusterNameRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"clusterNameRef,omitempty"`
 	// The name of the add-on. The name must match one of the names returned by
 	// ListAddons (https://docs.aws.amazon.com/eks/latest/APIReference/API_ListAddons.html).
 	// +kubebuilder:validation:Required

--- a/apis/v1alpha1/fargate_profile.go
+++ b/apis/v1alpha1/fargate_profile.go
@@ -28,8 +28,8 @@ type FargateProfileSpec struct {
 	// of the request.
 	ClientRequestToken *string `json:"clientRequestToken,omitempty"`
 	// The name of the Amazon EKS cluster to apply the Fargate profile to.
-	// +kubebuilder:validation:Required
-	ClusterName *string `json:"clusterName"`
+	ClusterName    *string                                  `json:"clusterName,omitempty"`
+	ClusterNameRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"clusterNameRef,omitempty"`
 	// The name of the Fargate profile.
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,5 +1,10 @@
 resources:
   Addon:
+    fields:
+      ClusterName:
+        references:
+          resource: Cluster
+          path: Spec.Name
     renames:
       operations:
         CreateAddon:
@@ -58,6 +63,11 @@ resources:
     update_operation:
       custom_method_name: customUpdate
   FargateProfile:
+    fields:
+      ClusterName:
+        references:
+          resource: Cluster
+          path: Spec.Name
     renames:
       operations:
         CreateFargateProfile:
@@ -87,6 +97,11 @@ resources:
         - MissingParameter
         - ValidationError
   Nodegroup:
+    fields:
+      ClusterName:
+        references:
+          resource: Cluster
+          path: Spec.Name
     renames:
       operations:
         CreateNodegroup:

--- a/apis/v1alpha1/nodegroup.go
+++ b/apis/v1alpha1/nodegroup.go
@@ -39,8 +39,8 @@ type NodegroupSpec struct {
 	// of the request.
 	ClientRequestToken *string `json:"clientRequestToken,omitempty"`
 	// The name of the cluster to create the node group in.
-	// +kubebuilder:validation:Required
-	ClusterName *string `json:"clusterName"`
+	ClusterName    *string                                  `json:"clusterName,omitempty"`
+	ClusterNameRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"clusterNameRef,omitempty"`
 	// The root device disk size (in GiB) for your node group instances. The default
 	// disk size is 20 GiB. If you specify launchTemplate, then don't specify diskSize,
 	// or the node group deployment will fail. For more information about using

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -189,6 +189,11 @@ func (in *AddonSpec) DeepCopyInto(out *AddonSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClusterNameRef != nil {
+		in, out := &in.ClusterNameRef, &out.ClusterNameRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)
@@ -939,6 +944,11 @@ func (in *FargateProfileSpec) DeepCopyInto(out *FargateProfileSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClusterNameRef != nil {
+		in, out := &in.ClusterNameRef, &out.ClusterNameRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)
@@ -1495,6 +1505,11 @@ func (in *NodegroupSpec) DeepCopyInto(out *NodegroupSpec) {
 		in, out := &in.ClusterName, &out.ClusterName
 		*out = new(string)
 		**out = **in
+	}
+	if in.ClusterNameRef != nil {
+		in, out := &in.ClusterNameRef, &out.ClusterNameRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DiskSize != nil {
 		in, out := &in.DiskSize, &out.DiskSize

--- a/config/crd/bases/eks.services.k8s.aws_addons.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_addons.yaml
@@ -48,6 +48,20 @@ spec:
               clusterName:
                 description: The name of the cluster to create the add-on for.
                 type: string
+              clusterNameRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: The name of the add-on. The name must match one of the
                   names returned by ListAddons (https://docs.aws.amazon.com/eks/latest/APIReference/API_ListAddons.html).
@@ -77,7 +91,6 @@ spec:
                   both of which you define.
                 type: object
             required:
-            - clusterName
             - name
             type: object
           status:

--- a/config/crd/bases/eks.services.k8s.aws_fargateprofiles.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_fargateprofiles.yaml
@@ -45,6 +45,20 @@ spec:
                 description: The name of the Amazon EKS cluster to apply the Fargate
                   profile to.
                 type: string
+              clusterNameRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: The name of the Fargate profile.
                 type: string
@@ -91,7 +105,6 @@ spec:
                   Fargate profile, such as the pods that are scheduled with it.
                 type: object
             required:
-            - clusterName
             - name
             - podExecutionRoleARN
             type: object

--- a/config/crd/bases/eks.services.k8s.aws_nodegroups.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_nodegroups.yaml
@@ -58,6 +58,20 @@ spec:
               clusterName:
                 description: The name of the cluster to create the node group in.
                 type: string
+              clusterNameRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               diskSize:
                 description: The root device disk size (in GiB) for your node group
                   instances. The default disk size is 20 GiB. If you specify launchTemplate,
@@ -217,7 +231,6 @@ spec:
                   in the Amazon EKS User Guide.
                 type: string
             required:
-            - clusterName
             - name
             - nodeRole
             - subnets

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,5 +1,10 @@
 resources:
   Addon:
+    fields:
+      ClusterName:
+        references:
+          resource: Cluster
+          path: Spec.Name
     renames:
       operations:
         CreateAddon:
@@ -58,6 +63,11 @@ resources:
     update_operation:
       custom_method_name: customUpdate
   FargateProfile:
+    fields:
+      ClusterName:
+        references:
+          resource: Cluster
+          path: Spec.Name
     renames:
       operations:
         CreateFargateProfile:
@@ -87,6 +97,11 @@ resources:
         - MissingParameter
         - ValidationError
   Nodegroup:
+    fields:
+      ClusterName:
+        references:
+          resource: Cluster
+          path: Spec.Name
     renames:
       operations:
         CreateNodegroup:

--- a/helm/crds/eks.services.k8s.aws_addons.yaml
+++ b/helm/crds/eks.services.k8s.aws_addons.yaml
@@ -48,6 +48,20 @@ spec:
               clusterName:
                 description: The name of the cluster to create the add-on for.
                 type: string
+              clusterNameRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: The name of the add-on. The name must match one of the
                   names returned by ListAddons (https://docs.aws.amazon.com/eks/latest/APIReference/API_ListAddons.html).
@@ -77,7 +91,6 @@ spec:
                   both of which you define.
                 type: object
             required:
-            - clusterName
             - name
             type: object
           status:

--- a/helm/crds/eks.services.k8s.aws_fargateprofiles.yaml
+++ b/helm/crds/eks.services.k8s.aws_fargateprofiles.yaml
@@ -45,6 +45,20 @@ spec:
                 description: The name of the Amazon EKS cluster to apply the Fargate
                   profile to.
                 type: string
+              clusterNameRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: The name of the Fargate profile.
                 type: string
@@ -91,7 +105,6 @@ spec:
                   Fargate profile, such as the pods that are scheduled with it.
                 type: object
             required:
-            - clusterName
             - name
             - podExecutionRoleARN
             type: object

--- a/helm/crds/eks.services.k8s.aws_nodegroups.yaml
+++ b/helm/crds/eks.services.k8s.aws_nodegroups.yaml
@@ -58,6 +58,20 @@ spec:
               clusterName:
                 description: The name of the cluster to create the node group in.
                 type: string
+              clusterNameRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               diskSize:
                 description: The root device disk size (in GiB) for your node group
                   instances. The default disk size is 20 GiB. If you specify launchTemplate,
@@ -217,7 +231,6 @@ spec:
                   in the Amazon EKS User Guide.
                 type: string
             required:
-            - clusterName
             - name
             - nodeRole
             - subnets

--- a/pkg/resource/addon/delta.go
+++ b/pkg/resource/addon/delta.go
@@ -62,6 +62,9 @@ func newResourceDelta(
 			delta.Add("Spec.ClusterName", a.ko.Spec.ClusterName, b.ko.Spec.ClusterName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.ClusterNameRef, b.ko.Spec.ClusterNameRef) {
+		delta.Add("Spec.ClusterNameRef", a.ko.Spec.ClusterNameRef, b.ko.Spec.ClusterNameRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {

--- a/pkg/resource/addon/references.go
+++ b/pkg/resource/addon/references.go
@@ -17,8 +17,15 @@ package addon
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
@@ -36,17 +43,90 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForClusterName(ctx, apiReader, namespace, ko)
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Addon) error {
+	if ko.Spec.ClusterNameRef != nil && ko.Spec.ClusterName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ClusterName", "ClusterNameRef")
+	}
+	if ko.Spec.ClusterNameRef == nil && ko.Spec.ClusterName == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterNameRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Addon) bool {
-	return false
+	return false || ko.Spec.ClusterNameRef != nil
+}
+
+// resolveReferenceForClusterName reads the resource referenced
+// from ClusterNameRef field and sets the ClusterName
+// from referenced resource
+func resolveReferenceForClusterName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Addon,
+) error {
+	if ko.Spec.ClusterNameRef != nil &&
+		ko.Spec.ClusterNameRef.From != nil {
+		arr := ko.Spec.ClusterNameRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := acksvcv1alpha1.Cluster{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Cluster",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			//TODO(vijtrip2) Uncomment below return statment once
+			// ConditionTypeResourceSynced(True/False) is set for all resources
+			//return ackerr.ResourceReferenceNotSyncedFor(
+			//	"Cluster",
+			//	namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Cluster",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		ko.Spec.ClusterName = obj.Spec.Name
+	}
+	return nil
 }

--- a/pkg/resource/addon/references.go
+++ b/pkg/resource/addon/references.go
@@ -92,7 +92,7 @@ func resolveReferenceForClusterName(
 			Namespace: namespace,
 			Name:      *arr.Name,
 		}
-		obj := acksvcv1alpha1.Cluster{}
+		obj := svcapitypes.Cluster{}
 		err := apiReader.Get(ctx, namespacedName, &obj)
 		if err != nil {
 			return err

--- a/pkg/resource/fargate_profile/delta.go
+++ b/pkg/resource/fargate_profile/delta.go
@@ -55,6 +55,9 @@ func newResourceDelta(
 			delta.Add("Spec.ClusterName", a.ko.Spec.ClusterName, b.ko.Spec.ClusterName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.ClusterNameRef, b.ko.Spec.ClusterNameRef) {
+		delta.Add("Spec.ClusterNameRef", a.ko.Spec.ClusterNameRef, b.ko.Spec.ClusterNameRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {

--- a/pkg/resource/fargate_profile/references.go
+++ b/pkg/resource/fargate_profile/references.go
@@ -92,7 +92,7 @@ func resolveReferenceForClusterName(
 			Namespace: namespace,
 			Name:      *arr.Name,
 		}
-		obj := acksvcv1alpha1.Cluster{}
+		obj := svcapitypes.Cluster{}
 		err := apiReader.Get(ctx, namespacedName, &obj)
 		if err != nil {
 			return err

--- a/pkg/resource/fargate_profile/references.go
+++ b/pkg/resource/fargate_profile/references.go
@@ -17,8 +17,15 @@ package fargate_profile
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
@@ -36,17 +43,90 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForClusterName(ctx, apiReader, namespace, ko)
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.FargateProfile) error {
+	if ko.Spec.ClusterNameRef != nil && ko.Spec.ClusterName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ClusterName", "ClusterNameRef")
+	}
+	if ko.Spec.ClusterNameRef == nil && ko.Spec.ClusterName == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterNameRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.FargateProfile) bool {
-	return false
+	return false || ko.Spec.ClusterNameRef != nil
+}
+
+// resolveReferenceForClusterName reads the resource referenced
+// from ClusterNameRef field and sets the ClusterName
+// from referenced resource
+func resolveReferenceForClusterName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.FargateProfile,
+) error {
+	if ko.Spec.ClusterNameRef != nil &&
+		ko.Spec.ClusterNameRef.From != nil {
+		arr := ko.Spec.ClusterNameRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := acksvcv1alpha1.Cluster{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Cluster",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			//TODO(vijtrip2) Uncomment below return statment once
+			// ConditionTypeResourceSynced(True/False) is set for all resources
+			//return ackerr.ResourceReferenceNotSyncedFor(
+			//	"Cluster",
+			//	namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Cluster",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		ko.Spec.ClusterName = obj.Spec.Name
+	}
+	return nil
 }

--- a/pkg/resource/nodegroup/delta.go
+++ b/pkg/resource/nodegroup/delta.go
@@ -70,6 +70,9 @@ func newResourceDelta(
 			delta.Add("Spec.ClusterName", a.ko.Spec.ClusterName, b.ko.Spec.ClusterName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.ClusterNameRef, b.ko.Spec.ClusterNameRef) {
+		delta.Add("Spec.ClusterNameRef", a.ko.Spec.ClusterNameRef, b.ko.Spec.ClusterNameRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DiskSize, b.ko.Spec.DiskSize) {
 		delta.Add("Spec.DiskSize", a.ko.Spec.DiskSize, b.ko.Spec.DiskSize)
 	} else if a.ko.Spec.DiskSize != nil && b.ko.Spec.DiskSize != nil {

--- a/pkg/resource/nodegroup/references.go
+++ b/pkg/resource/nodegroup/references.go
@@ -17,8 +17,15 @@ package nodegroup
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
@@ -36,17 +43,90 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForClusterName(ctx, apiReader, namespace, ko)
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Nodegroup) error {
+	if ko.Spec.ClusterNameRef != nil && ko.Spec.ClusterName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ClusterName", "ClusterNameRef")
+	}
+	if ko.Spec.ClusterNameRef == nil && ko.Spec.ClusterName == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterNameRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Nodegroup) bool {
-	return false
+	return false || ko.Spec.ClusterNameRef != nil
+}
+
+// resolveReferenceForClusterName reads the resource referenced
+// from ClusterNameRef field and sets the ClusterName
+// from referenced resource
+func resolveReferenceForClusterName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Nodegroup,
+) error {
+	if ko.Spec.ClusterNameRef != nil &&
+		ko.Spec.ClusterNameRef.From != nil {
+		arr := ko.Spec.ClusterNameRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := acksvcv1alpha1.Cluster{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Cluster",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			//TODO(vijtrip2) Uncomment below return statment once
+			// ConditionTypeResourceSynced(True/False) is set for all resources
+			//return ackerr.ResourceReferenceNotSyncedFor(
+			//	"Cluster",
+			//	namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Cluster",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		ko.Spec.ClusterName = obj.Spec.Name
+	}
+	return nil
 }

--- a/pkg/resource/nodegroup/references.go
+++ b/pkg/resource/nodegroup/references.go
@@ -92,7 +92,7 @@ func resolveReferenceForClusterName(
 			Namespace: namespace,
 			Name:      *arr.Name,
 		}
-		obj := acksvcv1alpha1.Cluster{}
+		obj := svcapitypes.Cluster{}
 		err := apiReader.Get(ctx, namespacedName, &obj)
 		if err != nil {
 			return err


### PR DESCRIPTION
Description of changes:
Add resource references to each of the custom resources to replace `ClusterName`. I have tested these changes manually and, while they work, are currently sub-optimal.

The generated code currently does not check for the `ResourceSynced` condition to be `true` before resolving the reference. Therefore, since all of these resources reference the cluster spec field, they immediately resolve. As a result, the resources immediately attempt to create - even though the cluster is still in `CREATING` status. Once https://github.com/aws-controllers-k8s/community/issues/1064 is properly implemented, and the code gating the `ResourceSynced` status is enabled, these resources should work flawlessly. 

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
