### PR TITLE
Fix `ResourceInUseException` when deleting cluster

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2022-02-28T18:05:07Z"
-  build_hash: 4724c496a77a35bd6d1d1a2cc415d342457a7463
-  go_version: go1.17.5
+  build_date: "2022-03-01T19:39:46Z"
+  build_hash: 7dff1f4590e623d17e58660b7dd1c66e22b5215a
+  go_version: go1.17.1
   version: v0.17.1
 api_directory_checksum: 50ce02741686341685d2a897fdcdd80c80e260d9
 api_version: v1alpha1

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-03-01T19:39:46Z"
+  build_date: "2022-03-01T19:48:47Z"
   build_hash: 7dff1f4590e623d17e58660b7dd1c66e22b5215a
   go_version: go1.17.1
   version: v0.17.1

--- a/pkg/resource/addon/references.go
+++ b/pkg/resource/addon/references.go
@@ -23,11 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+
+	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/cluster/references.go
+++ b/pkg/resource/cluster/references.go
@@ -19,8 +19,9 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+
+	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -706,6 +706,12 @@ func (rm *resourceManager) sdkDelete(
 	if clusterDeleting(r) {
 		return r, requeueWaitWhileDeleting
 	}
+	inUse, err := rm.clusterInUse(ctx, r)
+	if err != nil {
+		return nil, err
+	} else if inUse {
+		return r, requeueWaitWhileInUse
+	}
 
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {

--- a/pkg/resource/fargate_profile/references.go
+++ b/pkg/resource/fargate_profile/references.go
@@ -23,11 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+
+	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/nodegroup/references.go
+++ b/pkg/resource/nodegroup/references.go
@@ -23,11 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+
+	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/templates/hooks/cluster/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/cluster/sdk_delete_pre_build_request.go.tpl
@@ -1,3 +1,9 @@
 	if clusterDeleting(r) {
 		return r, requeueWaitWhileDeleting
 	}
+	inUse, err := rm.clusterInUse(ctx, r);
+	if err != nil {
+		return nil, err
+	} else if inUse {
+		return r, requeueWaitWhileInUse
+	}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1191

Description of changes:
Adds a hook that checks to see all nodegroups have been deleted from the cluster before it attempts to delete the cluster itself

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
