### PR TITLE
Requeue if cluster in use during update

### DIFF
--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -188,7 +188,7 @@ func (rm *resourceManager) customUpdate(
 
 			// Check to see if we've raced an async update call and need to
 			// requeue
-			if ok && awserr.Code() != "ResourceInUseException" {
+			if ok && awserr.Code() == "ResourceInUseException" {
 				return nil, requeueAfterAsyncUpdate()
 			}
 
@@ -202,7 +202,7 @@ func (rm *resourceManager) customUpdate(
 
 			// Check to see if we've raced an async update call and need to
 			// requeue
-			if ok && awserr.Code() != "ResourceInUseException" {
+			if ok && awserr.Code() == "ResourceInUseException" {
 				return nil, requeueAfterAsyncUpdate()
 			}
 

--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -184,12 +184,28 @@ func (rm *resourceManager) customUpdate(
 	}
 	if delta.DifferentAt("Spec.ResourcesVPCConfig") {
 		if err := rm.updateConfigResourcesVPCConfig(ctx, desired); err != nil {
+			awserr, ok := ackerr.AWSError(err)
+
+			// Check to see if we've raced an async update call and need to
+			// requeue
+			if ok && awserr.Code() != "ResourceInUseException" {
+				return nil, requeueAfterAsyncUpdate()
+			}
+
 			return nil, err
 		}
 		return returnClusterUpdating(desired)
 	}
 	if delta.DifferentAt("Spec.Version") {
 		if err := rm.updateVersion(ctx, desired); err != nil {
+			awserr, ok := ackerr.AWSError(err)
+
+			// Check to see if we've raced an async update call and need to
+			// requeue
+			if ok && awserr.Code() != "ResourceInUseException" {
+				return nil, requeueAfterAsyncUpdate()
+			}
+
 			return nil, err
 		}
 		return returnClusterUpdating(desired)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1192

Description of changes:
If a cluster update call races and queues an update before we are able to call update, requeue the update until it becomes free again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
