### PR TITLE
Add hooks for `FargateProfile` status and delta

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-03-01T20:58:52Z"
+  build_date: "2022-03-01T23:22:01Z"
   build_hash: 7dff1f4590e623d17e58660b7dd1c66e22b5215a
   go_version: go1.17.1
   version: v0.17.1
@@ -7,7 +7,7 @@ api_directory_checksum: 50ce02741686341685d2a897fdcdd80c80e260d9
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 794a511b629b00b81bfe943eaf41eedf7c780ff7
+  file_checksum: d001fb15bd0b8f654bfaa80e0762814216d374b8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -96,6 +96,15 @@ resources:
         - MissingAction
         - MissingParameter
         - ValidationError
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/fargate_profile/sdk_delete_pre_build_request.go.tpl
+    update_operation:
+      custom_method_name: customUpdate
   Nodegroup:
     fields:
       ClusterName:

--- a/generator.yaml
+++ b/generator.yaml
@@ -96,6 +96,15 @@ resources:
         - MissingAction
         - MissingParameter
         - ValidationError
+    hooks:
+      delta_pre_compare:
+        code: customPreCompare(a, b)
+      sdk_read_one_post_set_output:
+        template_path: hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/fargate_profile/sdk_delete_pre_build_request.go.tpl
+    update_operation:
+      custom_method_name: customUpdate
   Nodegroup:
     fields:
       ClusterName:

--- a/pkg/resource/fargate_profile/delta.go
+++ b/pkg/resource/fargate_profile/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.ClientRequestToken, b.ko.Spec.ClientRequestToken) {
 		delta.Add("Spec.ClientRequestToken", a.ko.Spec.ClientRequestToken, b.ko.Spec.ClientRequestToken)

--- a/pkg/resource/fargate_profile/hook.go
+++ b/pkg/resource/fargate_profile/hook.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fargate_profile
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/eks"
+)
+
+var (
+	UnableToUpdateError = "Changes to FargateProfile resources are not" +
+		" currently possible. To update the resource, delete and re-create it"
+)
+
+var (
+	requeueWaitWhileDeleting = ackrequeue.NeededAfter(
+		fmt.Errorf("profile is in '%s' state, cannot be modified or deleted", svcsdk.FargateProfileStatusDeleting),
+		ackrequeue.DefaultRequeueAfterDuration,
+	)
+)
+
+// profileActive returns true if the supplied EKS FargateProfile is in the
+// `Active` status
+func profileActive(r *resource) bool {
+	if r.ko.Status.Status == nil {
+		return false
+	}
+	ps := *r.ko.Status.Status
+	return ps == svcsdk.FargateProfileStatusActive
+}
+
+// profileDeleting returns true if the supplied EKS FargateProfile is in the
+// `Deleting` status
+func profileDeleting(r *resource) bool {
+	if r.ko.Status.Status == nil {
+		return false
+	}
+	ps := *r.ko.Status.Status
+	return ps == svcsdk.FargateProfileStatusDeleting
+}
+
+// customPreCompare ensures that default values of nil-able types are
+// appropriately replaced with empty maps or structs depending on the default
+// output of the SDK.
+func customPreCompare(
+	a *resource,
+	b *resource,
+) {
+	if a.ko.Spec.Tags == nil && b.ko.Spec.Tags != nil {
+		a.ko.Spec.Tags = map[string]*string{}
+	} else if a.ko.Spec.Tags != nil && b.ko.Spec.Tags == nil {
+		b.ko.Spec.Tags = map[string]*string{}
+	}
+}
+
+func (rm *resourceManager) customUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdate")
+	defer exit(err)
+
+	// Never allow any changes
+	updated = &resource{ko: desired.ko.DeepCopy()}
+	ackcondition.SetSynced(updated, corev1.ConditionFalse, &UnableToUpdateError, nil)
+	return updated, nil
+}

--- a/templates/hooks/fargate_profile/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/fargate_profile/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,3 @@
+	if profileDeleting(r) {
+		return r, requeueWaitWhileDeleting
+	}

--- a/templates/hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
@@ -1,0 +1,7 @@
+	if !profileActive(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	} else {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
+    }


### PR DESCRIPTION
Description of changes:
Add additional hooks to manage the status, and set defaults for the delta, of `FargateProfile`.
- Delta precompare to ignore uninitialised tags
- Reject all attempts to update (not supported by SDK) by setting `ResourceSynced` to `False`
- Prevent controller from attempting multiple deletes by checking for existing `DELETING` status 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
