### PR TITLE
Add in use exception check to retry update logging

### DIFF
--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -197,6 +197,12 @@ func (rm *resourceManager) customUpdate(
 			if !ok || awserr.Message() != LoggingNoChangesError {
 				return nil, err
 			}
+
+			// Check to see if we've raced an async update call and need to
+			// requeue
+			if ok && awserr.Code() == "ResourceInUseException" {
+				return nil, requeueAfterAsyncUpdate()
+			}
 		}
 		return returnClusterUpdating(desired)
 	}


### PR DESCRIPTION
Description of changes:
Just as in https://github.com/aws-controllers-k8s/eks-controller/pull/26, the `updateConfigLogging` sometimes races another cluster update call, returning a `ResourceInUseException`. This change adds a check for that exception and forces a requeue on the resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
