### PR TITLE
Use generator synced config for `FargateProfile`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-03-01T23:22:01Z"
+  build_date: "2022-03-02T18:17:17Z"
   build_hash: 7dff1f4590e623d17e58660b7dd1c66e22b5215a
   go_version: go1.17.1
   version: v0.17.1
@@ -7,7 +7,7 @@ api_directory_checksum: 50ce02741686341685d2a897fdcdd80c80e260d9
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: d001fb15bd0b8f654bfaa80e0762814216d374b8
+  file_checksum: 56a08a2624b3ec00e907af51f8d77f3d80337eee
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -99,12 +99,15 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(a, b)
-      sdk_read_one_post_set_output:
-        template_path: hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/fargate_profile/sdk_delete_pre_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdate
+    synced:
+      when:
+      - path: Status.Status
+        in:
+        - ACTIVE
   Nodegroup:
     fields:
       ClusterName:

--- a/generator.yaml
+++ b/generator.yaml
@@ -99,12 +99,15 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(a, b)
-      sdk_read_one_post_set_output:
-        template_path: hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/fargate_profile/sdk_delete_pre_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdate
+    synced:
+      when:
+      - path: Status.Status
+        in:
+        - ACTIVE
   Nodegroup:
     fields:
       ClusterName:

--- a/pkg/resource/fargate_profile/hook.go
+++ b/pkg/resource/fargate_profile/hook.go
@@ -38,16 +38,6 @@ var (
 	)
 )
 
-// profileActive returns true if the supplied EKS FargateProfile is in the
-// `Active` status
-func profileActive(r *resource) bool {
-	if r.ko.Status.Status == nil {
-		return false
-	}
-	ps := *r.ko.Status.Status
-	return ps == svcsdk.FargateProfileStatusActive
-}
-
 // profileDeleting returns true if the supplied EKS FargateProfile is in the
 // `Deleting` status
 func profileDeleting(r *resource) bool {

--- a/pkg/resource/fargate_profile/manager.go
+++ b/pkg/resource/fargate_profile/manager.go
@@ -256,6 +256,11 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	statusCandidates := []string{"ACTIVE"}
+	if !ackutil.InStrings(*r.ko.Status.Status, statusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/fargate_profile/sdk.go
+++ b/pkg/resource/fargate_profile/sdk.go
@@ -158,14 +158,6 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	if !profileActive(&resource{ko}) {
-		// Setting resource synced condition to false will trigger a requeue of
-		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-	} else {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
-	}
-
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/fargate_profile/sdk_read_one_post_set_output.go.tpl
@@ -1,7 +1,0 @@
-	if !profileActive(&resource{ko}) {
-		// Setting resource synced condition to false will trigger a requeue of
-		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-	} else {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
-    }


### PR DESCRIPTION
Description of changes:
Use the `synced.when` pattern in the generator config to manage the `ResourceSynced` condition from the `FargateProfile` `Status.Status`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
