### PR TITLE
release artifacts for v0.1.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2022-05-04T06:33:59Z"
-  build_hash: 95f81d38b4dcdb28193e1f8b04c1c6f995c26cb9
-  go_version: go1.17.8
-  version: v0.18.4-7-g95f81d3
-api_directory_checksum: 5a61ee8ddc2e5b47eec47516b9b5902a89c1e513
+  build_date: "2022-05-05T22:12:37Z"
+  build_hash: 52584bbac484b4746c5c93dbad9d0cd90fd9d700
+  go_version: go1.17.5
+  version: v0.18.4-9-g52584bb
+api_directory_checksum: 5fc33b04db77ac596030ce3a031a0310da0b923f
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.28
 generator_config_info:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/eks-controller
-  newTag: v0.1.0
+  newTag: v0.1.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: eks-chart
 description: A Helm chart for the ACK service controller for Amazon Elastic Kubernetes Service (EKS)
-version: v0.1.0
-appVersion: v0.1.0
+version: v0.1.1
+appVersion: v0.1.1
 home: https://github.com/aws-controllers-k8s/eks-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/eks-controller:v0.1.0".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/eks-controller:v0.1.1".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/eks-controller
-  tag: v0.1.0
+  tag: v0.1.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Issue : https://github.com/aws-controllers-k8s/community/issues/1283

Description of changes:

* release artifacts for `v0.1.1` after updating aws-sdk-go to `v1.42.28`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
