### PR TITLE
Add nil guard for nodegroup config update structs

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-05-09T19:51:01Z"
-  build_hash: c6efa6ac643edb21219e0763541b2558718b5fe6
-  go_version: go1.18.1
-  version: v0.18.4-10-gc6efa6a
+  build_date: "2022-06-08T19:33:40Z"
+  build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
+  go_version: go1.18.3
+  version: v0.18.4-15-g6acf40f
 api_directory_checksum: 7b070fe012124ee552759771abc96d313cd2be43
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.28

--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -332,10 +332,16 @@ func (rm *resourceManager) updateConfig(
 	input := &svcsdk.UpdateNodegroupConfigInput{
 		NodegroupName: desired.ko.Spec.Name,
 		ClusterName:   desired.ko.Spec.ClusterName,
-		ScalingConfig: rm.newNodegroupScalingConfig(desired),
-		UpdateConfig:  rm.newNodegroupUpdateConfig(desired),
 		Labels:        newUpdateLabelsPayload(desired, latest),
 		Taints:        newUpdateTaintsPayload(desired, latest),
+	}
+
+	if desired.ko.Spec.ScalingConfig != nil {
+		input.SetScalingConfig(rm.newNodegroupScalingConfig(desired))
+	}
+
+	if desired.ko.Spec.UpdateConfig != nil {
+		input.SetUpdateConfig(rm.newNodegroupUpdateConfig(desired))
 	}
 
 	_, err = rm.sdkapi.UpdateNodegroupConfigWithContext(ctx, input)

--- a/test/e2e/tests/test_nodegroup.py
+++ b/test/e2e/tests/test_nodegroup.py
@@ -107,12 +107,17 @@ class TestNodegroup:
 
         wait_for_nodegroup_active(eks_client, cluster_name, nodegroup_name)
 
-        # Update the logging and VPC config fields
+        # Update the update and scaling configs fields
         updates = {
             "spec": {
                 "updateConfig": {
                     "maxUnavailable": None,
                     "maxUnavailablePercentage": 15
+                },
+                "scalingConfig": {
+                    "minSize": 2,
+                    "maxSize": 2,
+                    "desiredSize": 2,
                 }
             }
         }
@@ -132,6 +137,9 @@ class TestNodegroup:
         )
 
         assert aws_res["nodegroup"]["updateConfig"]["maxUnavailablePercentage"] == 15
+        assert aws_res["nodegroup"]["scalingConfig"]["minSize"] == 2
+        assert aws_res["nodegroup"]["scalingConfig"]["maxSize"] == 2
+        assert aws_res["nodegroup"]["scalingConfig"]["desiredSize"] == 2
 
         updates = {
             "spec": {


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1320

Description of changes:
Ensures the `ScalingConfig` and `UpdateConfig` properties are non-nil before attempting to add them to the `UpdateNodegroupConfig` request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
