### PR TITLE
Add support for addon updates

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -21,6 +21,9 @@ resources:
         DeleteAddon:
           input_fields:
             AddonName: Name
+        UpdateAddon:
+          input_fields:
+            AddonName: Name
     exceptions:
       errors:
         404:

--- a/generator.yaml
+++ b/generator.yaml
@@ -21,6 +21,9 @@ resources:
         DeleteAddon:
           input_fields:
             AddonName: Name
+        UpdateAddon:
+          input_fields:
+            AddonName: Name
     exceptions:
       errors:
         404:

--- a/pkg/resource/addon/sdk.go
+++ b/pkg/resource/addon/sdk.go
@@ -407,6 +407,9 @@ func (rm *resourceManager) newUpdateRequestPayload(
 ) (*svcsdk.UpdateAddonInput, error) {
 	res := &svcsdk.UpdateAddonInput{}
 
+	if r.ko.Spec.Name != nil {
+		res.SetAddonName(*r.ko.Spec.Name)
+	}
 	if r.ko.Spec.AddonVersion != nil {
 		res.SetAddonVersion(*r.ko.Spec.AddonVersion)
 	}

--- a/pkg/resource/nodegroup/sdk.go
+++ b/pkg/resource/nodegroup/sdk.go
@@ -625,7 +625,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	// We expect the nodegorup to be in 'CREATING' status since we just issued
+	// We expect the nodegroup to be in 'CREATING' status since we just issued
 	// the call to create it, but I suppose it doesn't hurt to check here.
 	if nodegroupCreating(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of

--- a/templates/hooks/nodegroup/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/nodegroup/sdk_create_post_set_output.go.tpl
@@ -1,4 +1,4 @@
-	// We expect the nodegorup to be in 'CREATING' status since we just issued
+	// We expect the nodegroup to be in 'CREATING' status since we just issued
 	// the call to create it, but I suppose it doesn't hurt to check here.
 	if nodegroupCreating(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

Issue #, if available:

Description of changes:
Issue affects `public.ecr.aws/aws-controllers-k8s/eks-controller:v0.1.4`
Currently unable to update Addon with the below exception.
```
  - lastTransitionTime: "2022-08-12T14:48:28Z"
    message: Unable to determine if desired resource state matches latest observed
      state
    reason: |
      InvalidParameter: 1 validation error(s) found.
      - missing required field, UpdateAddonInput.AddonName.
```
the Name is a requirement due to the shape ->  https://github.com/aws/aws-sdk-go/blob/ec3763d8d5abacbf47c0b4296fb5d27821297508/models/apis/eks/2017-11-01/api-2.json#L2128-L2133
This same configuration exists for `CreateAddon | DescribeAddon | DeleteAddon`
With the change in place the Addon upgrades as expected.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
