### PR TITLE
Support lists of structs containing refs and `ClearResolvedReferences`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-22T21:55:10Z"
-  build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
-  go_version: go1.19
-  version: v0.25.0
-api_directory_checksum: 1f80f5565b681614b1bef5950ba11a1df0b8b486
+  build_date: "2023-04-27T00:15:44Z"
+  build_hash: e69321ed2d9567bf2d439af970b7466086f0b4fa
+  go_version: go1.19.3
+  version: v0.25.0-6-ge69321e
+api_directory_checksum: 7b6d896d0ab38655f44c9c13814677ec7fd82a65
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.195
 generator_config_info:
-  file_checksum: 5f43816010007fa46c7804e1ad4e9493b2820744
+  file_checksum: 49795892b3dc1f86884844e0802cd0d4c642650a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/aws-controllers-k8s/ec2-controller v0.0.10
 	github.com/aws-controllers-k8s/iam-controller v0.0.8
-	github.com/aws-controllers-k8s/runtime v0.25.0
+	github.com/aws-controllers-k8s/runtime v0.26.0
 	github.com/aws/aws-sdk-go v1.44.195
 	github.com/go-logr/logr v1.2.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/aws-controllers-k8s/ec2-controller v0.0.10 h1:RVGezMt5aySJZSj+h77SrHZ
 github.com/aws-controllers-k8s/ec2-controller v0.0.10/go.mod h1:N8vii7yTsYHmMjOhs4kl8MpJlBWIEHQFm11HO16J9C4=
 github.com/aws-controllers-k8s/iam-controller v0.0.8 h1:7F4W45I7l30jZZGS8FEesScJmOcnPASCoa1sHBcTLNI=
 github.com/aws-controllers-k8s/iam-controller v0.0.8/go.mod h1:IibRVHZc+MEISws4FXQVC0rGwTeePm/O1Pk4kpXq5x0=
-github.com/aws-controllers-k8s/runtime v0.25.0 h1:6SYa8qmbw+Yil5/LodF7LmIGxBhpjz4QEIvNjpeRuoc=
-github.com/aws-controllers-k8s/runtime v0.25.0/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
+github.com/aws-controllers-k8s/runtime v0.26.0 h1:XKqygFzHSBtM74Ov9IroZbyCVeYei9Eskp4aKbJ2SFw=
+github.com/aws-controllers-k8s/runtime v0.26.0/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
 github.com/aws/aws-sdk-go v1.44.195 h1:d5xFL0N83Fpsq2LFiHgtBUHknCRUPGHdOlCWt/jtOJs=
 github.com/aws/aws-sdk-go v1.44.195/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/resource/cluster/references.go
+++ b/pkg/resource/cluster/references.go
@@ -26,7 +26,6 @@ import (
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -42,55 +41,86 @@ import (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
+// ClearResolvedReferences removes any reference values that were made
+// concrete in the spec. It returns a copy of the input AWSResource which
+// contains the original *Ref values, but none of their respective concrete
+// values.
+func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.ResourcesVPCConfig != nil {
+		if len(ko.Spec.ResourcesVPCConfig.SecurityGroupRefs) > 0 {
+			ko.Spec.ResourcesVPCConfig.SecurityGroupIDs = nil
+		}
+	}
+
+	if ko.Spec.ResourcesVPCConfig != nil {
+		if len(ko.Spec.ResourcesVPCConfig.SubnetRefs) > 0 {
+			ko.Spec.ResourcesVPCConfig.SubnetIDs = nil
+		}
+	}
+
+	if ko.Spec.RoleRef != nil {
+		ko.Spec.RoleARN = nil
+	}
+
+	return &resource{ko}
+}
+
 // ResolveReferences finds if there are any Reference field(s) present
-// inside AWSResource passed in the parameter and attempts to resolve
-// those reference field(s) into target field(s).
-// It returns an AWSResource with resolved reference(s), and an error if the
-// passed AWSResource's reference field(s) cannot be resolved.
-// This method also adds/updates the ConditionTypeReferencesResolved for the
-// AWSResource.
+// inside AWSResource passed in the parameter and attempts to resolve those
+// reference field(s) into their respective target field(s). It returns a
+// copy of the input AWSResource with resolved reference(s), a boolean which
+// is set to true if the resource contains any references (regardless of if
+// they are resolved successfully) and an error if the passed AWSResource's
+// reference field(s) could not be resolved.
 func (rm *resourceManager) ResolveReferences(
 	ctx context.Context,
 	apiReader client.Reader,
 	res acktypes.AWSResource,
-) (acktypes.AWSResource, error) {
+) (acktypes.AWSResource, bool, error) {
 	namespace := res.MetaObject().GetNamespace()
-	ko := rm.concreteResource(res).ko.DeepCopy()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if err == nil {
-		err = resolveReferenceForResourcesVPCConfig_SecurityGroupIDs(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForResourcesVPCConfig_SubnetIDs(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForRoleARN(ctx, apiReader, namespace, ko)
+	if fieldHasReferences, err := rm.resolveReferenceForResourcesVPCConfig_SecurityGroupIDs(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	// If there was an error while resolving any reference, reset all the
-	// resolved values so that they do not get persisted inside etcd
-	if err != nil {
-		ko = rm.concreteResource(res).ko.DeepCopy()
+	if fieldHasReferences, err := rm.resolveReferenceForResourcesVPCConfig_SubnetIDs(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
-	if hasNonNilReferences(ko) {
-		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+
+	if fieldHasReferences, err := rm.resolveReferenceForRoleARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
-	return &resource{ko}, err
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Cluster) error {
+
 	if ko.Spec.ResourcesVPCConfig != nil {
-		if ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil && ko.Spec.ResourcesVPCConfig.SecurityGroupIDs != nil {
+		if len(ko.Spec.ResourcesVPCConfig.SecurityGroupRefs) > 0 && len(ko.Spec.ResourcesVPCConfig.SecurityGroupIDs) > 0 {
 			return ackerr.ResourceReferenceAndIDNotSupportedFor("ResourcesVPCConfig.SecurityGroupIDs", "ResourcesVPCConfig.SecurityGroupRefs")
 		}
 	}
+
 	if ko.Spec.ResourcesVPCConfig != nil {
-		if ko.Spec.ResourcesVPCConfig.SubnetRefs != nil && ko.Spec.ResourcesVPCConfig.SubnetIDs != nil {
+		if len(ko.Spec.ResourcesVPCConfig.SubnetRefs) > 0 && len(ko.Spec.ResourcesVPCConfig.SubnetIDs) > 0 {
 			return ackerr.ResourceReferenceAndIDNotSupportedFor("ResourcesVPCConfig.SubnetIDs", "ResourcesVPCConfig.SubnetRefs")
 		}
 	}
+
 	if ko.Spec.RoleRef != nil && ko.Spec.RoleARN != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("RoleARN", "RoleRef")
 	}
@@ -100,43 +130,37 @@ func validateReferenceFields(ko *svcapitypes.Cluster) error {
 	return nil
 }
 
-// hasNonNilReferences returns true if resource contains a reference to another
-// resource
-func hasNonNilReferences(ko *svcapitypes.Cluster) bool {
-	return false || (ko.Spec.ResourcesVPCConfig != nil && ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil) || (ko.Spec.ResourcesVPCConfig != nil && ko.Spec.ResourcesVPCConfig.SubnetRefs != nil) || (ko.Spec.RoleRef != nil)
-}
-
 // resolveReferenceForResourcesVPCConfig_SecurityGroupIDs reads the resource referenced
 // from ResourcesVPCConfig.SecurityGroupRefs field and sets the ResourcesVPCConfig.SecurityGroupIDs
-// from referenced resource
-func resolveReferenceForResourcesVPCConfig_SecurityGroupIDs(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForResourcesVPCConfig_SecurityGroupIDs(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Cluster,
-) error {
-	if ko.Spec.ResourcesVPCConfig == nil {
-		return nil
-	}
+) (hasReferences bool, err error) {
 	if ko.Spec.ResourcesVPCConfig != nil {
-		if len(ko.Spec.ResourcesVPCConfig.SecurityGroupRefs) > 0 {
-			resolved1 := []*string{}
-			for _, iter1 := range ko.Spec.ResourcesVPCConfig.SecurityGroupRefs {
-				arr := iter1.From
-				if arr == nil || arr.Name == nil || *arr.Name == "" {
-					return fmt.Errorf("provided resource reference is nil or empty: ResourcesVPCConfig.SecurityGroupRefs")
+		for _, f0iter := range ko.Spec.ResourcesVPCConfig.SecurityGroupRefs {
+			if f0iter != nil && f0iter.From != nil {
+				hasReferences = true
+				arr := f0iter.From
+				if arr.Name == nil || *arr.Name == "" {
+					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ResourcesVPCConfig.SecurityGroupRefs")
 				}
 				obj := &ec2apitypes.SecurityGroup{}
 				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-					return err
+					return hasReferences, err
 				}
-				resolved1 = append(resolved1, (*string)(obj.Status.ID))
+				if ko.Spec.ResourcesVPCConfig.SecurityGroupIDs == nil {
+					ko.Spec.ResourcesVPCConfig.SecurityGroupIDs = make([]*string, 0, 1)
+				}
+				ko.Spec.ResourcesVPCConfig.SecurityGroupIDs = append(ko.Spec.ResourcesVPCConfig.SecurityGroupIDs, (*string)(obj.Status.ID))
 			}
-			ko.Spec.ResourcesVPCConfig.SecurityGroupIDs = resolved1
 		}
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_SecurityGroup looks up whether a referenced resource
@@ -192,35 +216,35 @@ func getReferencedResourceState_SecurityGroup(
 
 // resolveReferenceForResourcesVPCConfig_SubnetIDs reads the resource referenced
 // from ResourcesVPCConfig.SubnetRefs field and sets the ResourcesVPCConfig.SubnetIDs
-// from referenced resource
-func resolveReferenceForResourcesVPCConfig_SubnetIDs(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForResourcesVPCConfig_SubnetIDs(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Cluster,
-) error {
-	if ko.Spec.ResourcesVPCConfig == nil {
-		return nil
-	}
+) (hasReferences bool, err error) {
 	if ko.Spec.ResourcesVPCConfig != nil {
-		if len(ko.Spec.ResourcesVPCConfig.SubnetRefs) > 0 {
-			resolved1 := []*string{}
-			for _, iter1 := range ko.Spec.ResourcesVPCConfig.SubnetRefs {
-				arr := iter1.From
-				if arr == nil || arr.Name == nil || *arr.Name == "" {
-					return fmt.Errorf("provided resource reference is nil or empty: ResourcesVPCConfig.SubnetRefs")
+		for _, f0iter := range ko.Spec.ResourcesVPCConfig.SubnetRefs {
+			if f0iter != nil && f0iter.From != nil {
+				hasReferences = true
+				arr := f0iter.From
+				if arr.Name == nil || *arr.Name == "" {
+					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ResourcesVPCConfig.SubnetRefs")
 				}
 				obj := &ec2apitypes.Subnet{}
 				if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-					return err
+					return hasReferences, err
 				}
-				resolved1 = append(resolved1, (*string)(obj.Status.SubnetID))
+				if ko.Spec.ResourcesVPCConfig.SubnetIDs == nil {
+					ko.Spec.ResourcesVPCConfig.SubnetIDs = make([]*string, 0, 1)
+				}
+				ko.Spec.ResourcesVPCConfig.SubnetIDs = append(ko.Spec.ResourcesVPCConfig.SubnetIDs, (*string)(obj.Status.SubnetID))
 			}
-			ko.Spec.ResourcesVPCConfig.SubnetIDs = resolved1
 		}
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Subnet looks up whether a referenced resource
@@ -276,26 +300,28 @@ func getReferencedResourceState_Subnet(
 
 // resolveReferenceForRoleARN reads the resource referenced
 // from RoleRef field and sets the RoleARN
-// from referenced resource
-func resolveReferenceForRoleARN(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForRoleARN(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Cluster,
-) error {
+) (hasReferences bool, err error) {
 	if ko.Spec.RoleRef != nil && ko.Spec.RoleRef.From != nil {
+		hasReferences = true
 		arr := ko.Spec.RoleRef.From
-		if arr == nil || arr.Name == nil || *arr.Name == "" {
-			return fmt.Errorf("provided resource reference is nil or empty: RoleRef")
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: RoleRef")
 		}
 		obj := &iamapitypes.Role{}
 		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return err
+			return hasReferences, err
 		}
 		ko.Spec.RoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Role looks up whether a referenced resource

--- a/pkg/resource/fargate_profile/references.go
+++ b/pkg/resource/fargate_profile/references.go
@@ -26,7 +26,6 @@ import (
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -39,91 +38,114 @@ import (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
+// ClearResolvedReferences removes any reference values that were made
+// concrete in the spec. It returns a copy of the input AWSResource which
+// contains the original *Ref values, but none of their respective concrete
+// values.
+func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.ClusterRef != nil {
+		ko.Spec.ClusterName = nil
+	}
+
+	if ko.Spec.PodExecutionRoleRef != nil {
+		ko.Spec.PodExecutionRoleARN = nil
+	}
+
+	if len(ko.Spec.SubnetRefs) > 0 {
+		ko.Spec.Subnets = nil
+	}
+
+	return &resource{ko}
+}
+
 // ResolveReferences finds if there are any Reference field(s) present
-// inside AWSResource passed in the parameter and attempts to resolve
-// those reference field(s) into target field(s).
-// It returns an AWSResource with resolved reference(s), and an error if the
-// passed AWSResource's reference field(s) cannot be resolved.
-// This method also adds/updates the ConditionTypeReferencesResolved for the
-// AWSResource.
+// inside AWSResource passed in the parameter and attempts to resolve those
+// reference field(s) into their respective target field(s). It returns a
+// copy of the input AWSResource with resolved reference(s), a boolean which
+// is set to true if the resource contains any references (regardless of if
+// they are resolved successfully) and an error if the passed AWSResource's
+// reference field(s) could not be resolved.
 func (rm *resourceManager) ResolveReferences(
 	ctx context.Context,
 	apiReader client.Reader,
 	res acktypes.AWSResource,
-) (acktypes.AWSResource, error) {
+) (acktypes.AWSResource, bool, error) {
 	namespace := res.MetaObject().GetNamespace()
-	ko := rm.concreteResource(res).ko.DeepCopy()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if err == nil {
-		err = resolveReferenceForClusterName(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForPodExecutionRoleARN(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForSubnets(ctx, apiReader, namespace, ko)
+	if fieldHasReferences, err := rm.resolveReferenceForClusterName(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	// If there was an error while resolving any reference, reset all the
-	// resolved values so that they do not get persisted inside etcd
-	if err != nil {
-		ko = rm.concreteResource(res).ko.DeepCopy()
+	if fieldHasReferences, err := rm.resolveReferenceForPodExecutionRoleARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
-	if hasNonNilReferences(ko) {
-		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+
+	if fieldHasReferences, err := rm.resolveReferenceForSubnets(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
-	return &resource{ko}, err
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.FargateProfile) error {
+
 	if ko.Spec.ClusterRef != nil && ko.Spec.ClusterName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("ClusterName", "ClusterRef")
 	}
 	if ko.Spec.ClusterRef == nil && ko.Spec.ClusterName == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterRef")
 	}
+
 	if ko.Spec.PodExecutionRoleRef != nil && ko.Spec.PodExecutionRoleARN != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("PodExecutionRoleARN", "PodExecutionRoleRef")
 	}
 	if ko.Spec.PodExecutionRoleRef == nil && ko.Spec.PodExecutionRoleARN == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("PodExecutionRoleARN", "PodExecutionRoleRef")
 	}
-	if ko.Spec.SubnetRefs != nil && ko.Spec.Subnets != nil {
+
+	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.Subnets) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("Subnets", "SubnetRefs")
 	}
 	return nil
 }
 
-// hasNonNilReferences returns true if resource contains a reference to another
-// resource
-func hasNonNilReferences(ko *svcapitypes.FargateProfile) bool {
-	return false || (ko.Spec.ClusterRef != nil) || (ko.Spec.PodExecutionRoleRef != nil) || (ko.Spec.SubnetRefs != nil)
-}
-
 // resolveReferenceForClusterName reads the resource referenced
 // from ClusterRef field and sets the ClusterName
-// from referenced resource
-func resolveReferenceForClusterName(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForClusterName(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.FargateProfile,
-) error {
+) (hasReferences bool, err error) {
 	if ko.Spec.ClusterRef != nil && ko.Spec.ClusterRef.From != nil {
+		hasReferences = true
 		arr := ko.Spec.ClusterRef.From
-		if arr == nil || arr.Name == nil || *arr.Name == "" {
-			return fmt.Errorf("provided resource reference is nil or empty: ClusterRef")
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ClusterRef")
 		}
 		obj := &svcapitypes.Cluster{}
 		if err := getReferencedResourceState_Cluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return err
+			return hasReferences, err
 		}
 		ko.Spec.ClusterName = (*string)(obj.Spec.Name)
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Cluster looks up whether a referenced resource
@@ -179,26 +201,28 @@ func getReferencedResourceState_Cluster(
 
 // resolveReferenceForPodExecutionRoleARN reads the resource referenced
 // from PodExecutionRoleRef field and sets the PodExecutionRoleARN
-// from referenced resource
-func resolveReferenceForPodExecutionRoleARN(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForPodExecutionRoleARN(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.FargateProfile,
-) error {
+) (hasReferences bool, err error) {
 	if ko.Spec.PodExecutionRoleRef != nil && ko.Spec.PodExecutionRoleRef.From != nil {
+		hasReferences = true
 		arr := ko.Spec.PodExecutionRoleRef.From
-		if arr == nil || arr.Name == nil || *arr.Name == "" {
-			return fmt.Errorf("provided resource reference is nil or empty: PodExecutionRoleRef")
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PodExecutionRoleRef")
 		}
 		obj := &iamapitypes.Role{}
 		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return err
+			return hasReferences, err
 		}
 		ko.Spec.PodExecutionRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Role looks up whether a referenced resource
@@ -254,30 +278,33 @@ func getReferencedResourceState_Role(
 
 // resolveReferenceForSubnets reads the resource referenced
 // from SubnetRefs field and sets the Subnets
-// from referenced resource
-func resolveReferenceForSubnets(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSubnets(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.FargateProfile,
-) error {
-	if len(ko.Spec.SubnetRefs) > 0 {
-		resolved0 := []*string{}
-		for _, iter0 := range ko.Spec.SubnetRefs {
-			arr := iter0.From
-			if arr == nil || arr.Name == nil || *arr.Name == "" {
-				return fmt.Errorf("provided resource reference is nil or empty: SubnetRefs")
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.SubnetRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SubnetRefs")
 			}
 			obj := &ec2apitypes.Subnet{}
 			if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-				return err
+				return hasReferences, err
 			}
-			resolved0 = append(resolved0, (*string)(obj.Status.SubnetID))
+			if ko.Spec.Subnets == nil {
+				ko.Spec.Subnets = make([]*string, 0, 1)
+			}
+			ko.Spec.Subnets = append(ko.Spec.Subnets, (*string)(obj.Status.SubnetID))
 		}
-		ko.Spec.Subnets = resolved0
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Subnet looks up whether a referenced resource

--- a/pkg/resource/nodegroup/references.go
+++ b/pkg/resource/nodegroup/references.go
@@ -26,7 +26,6 @@ import (
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -42,102 +41,135 @@ import (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
+// ClearResolvedReferences removes any reference values that were made
+// concrete in the spec. It returns a copy of the input AWSResource which
+// contains the original *Ref values, but none of their respective concrete
+// values.
+func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.ClusterRef != nil {
+		ko.Spec.ClusterName = nil
+	}
+
+	if ko.Spec.NodeRoleRef != nil {
+		ko.Spec.NodeRole = nil
+	}
+
+	if ko.Spec.RemoteAccess != nil {
+		if len(ko.Spec.RemoteAccess.SourceSecurityGroupRefs) > 0 {
+			ko.Spec.RemoteAccess.SourceSecurityGroups = nil
+		}
+	}
+
+	if len(ko.Spec.SubnetRefs) > 0 {
+		ko.Spec.Subnets = nil
+	}
+
+	return &resource{ko}
+}
+
 // ResolveReferences finds if there are any Reference field(s) present
-// inside AWSResource passed in the parameter and attempts to resolve
-// those reference field(s) into target field(s).
-// It returns an AWSResource with resolved reference(s), and an error if the
-// passed AWSResource's reference field(s) cannot be resolved.
-// This method also adds/updates the ConditionTypeReferencesResolved for the
-// AWSResource.
+// inside AWSResource passed in the parameter and attempts to resolve those
+// reference field(s) into their respective target field(s). It returns a
+// copy of the input AWSResource with resolved reference(s), a boolean which
+// is set to true if the resource contains any references (regardless of if
+// they are resolved successfully) and an error if the passed AWSResource's
+// reference field(s) could not be resolved.
 func (rm *resourceManager) ResolveReferences(
 	ctx context.Context,
 	apiReader client.Reader,
 	res acktypes.AWSResource,
-) (acktypes.AWSResource, error) {
+) (acktypes.AWSResource, bool, error) {
 	namespace := res.MetaObject().GetNamespace()
-	ko := rm.concreteResource(res).ko.DeepCopy()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if err == nil {
-		err = resolveReferenceForClusterName(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForNodeRole(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForRemoteAccess_SourceSecurityGroups(ctx, apiReader, namespace, ko)
-	}
-	if err == nil {
-		err = resolveReferenceForSubnets(ctx, apiReader, namespace, ko)
+	if fieldHasReferences, err := rm.resolveReferenceForClusterName(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	// If there was an error while resolving any reference, reset all the
-	// resolved values so that they do not get persisted inside etcd
-	if err != nil {
-		ko = rm.concreteResource(res).ko.DeepCopy()
+	if fieldHasReferences, err := rm.resolveReferenceForNodeRole(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
-	if hasNonNilReferences(ko) {
-		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+
+	if fieldHasReferences, err := rm.resolveReferenceForRemoteAccess_SourceSecurityGroups(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
-	return &resource{ko}, err
+
+	if fieldHasReferences, err := rm.resolveReferenceForSubnets(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Nodegroup) error {
+
 	if ko.Spec.ClusterRef != nil && ko.Spec.ClusterName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("ClusterName", "ClusterRef")
 	}
 	if ko.Spec.ClusterRef == nil && ko.Spec.ClusterName == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterRef")
 	}
+
 	if ko.Spec.NodeRoleRef != nil && ko.Spec.NodeRole != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("NodeRole", "NodeRoleRef")
 	}
 	if ko.Spec.NodeRoleRef == nil && ko.Spec.NodeRole == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("NodeRole", "NodeRoleRef")
 	}
+
 	if ko.Spec.RemoteAccess != nil {
-		if ko.Spec.RemoteAccess.SourceSecurityGroupRefs != nil && ko.Spec.RemoteAccess.SourceSecurityGroups != nil {
+		if len(ko.Spec.RemoteAccess.SourceSecurityGroupRefs) > 0 && len(ko.Spec.RemoteAccess.SourceSecurityGroups) > 0 {
 			return ackerr.ResourceReferenceAndIDNotSupportedFor("RemoteAccess.SourceSecurityGroups", "RemoteAccess.SourceSecurityGroupRefs")
 		}
 	}
-	if ko.Spec.SubnetRefs != nil && ko.Spec.Subnets != nil {
+
+	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.Subnets) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("Subnets", "SubnetRefs")
 	}
-	if ko.Spec.SubnetRefs == nil && ko.Spec.Subnets == nil {
+	if len(ko.Spec.SubnetRefs) == 0 && len(ko.Spec.Subnets) == 0 {
 		return ackerr.ResourceReferenceOrIDRequiredFor("Subnets", "SubnetRefs")
 	}
 	return nil
 }
 
-// hasNonNilReferences returns true if resource contains a reference to another
-// resource
-func hasNonNilReferences(ko *svcapitypes.Nodegroup) bool {
-	return false || (ko.Spec.ClusterRef != nil) || (ko.Spec.NodeRoleRef != nil) || (ko.Spec.RemoteAccess != nil && ko.Spec.RemoteAccess.SourceSecurityGroupRefs != nil) || (ko.Spec.SubnetRefs != nil)
-}
-
 // resolveReferenceForClusterName reads the resource referenced
 // from ClusterRef field and sets the ClusterName
-// from referenced resource
-func resolveReferenceForClusterName(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForClusterName(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Nodegroup,
-) error {
+) (hasReferences bool, err error) {
 	if ko.Spec.ClusterRef != nil && ko.Spec.ClusterRef.From != nil {
+		hasReferences = true
 		arr := ko.Spec.ClusterRef.From
-		if arr == nil || arr.Name == nil || *arr.Name == "" {
-			return fmt.Errorf("provided resource reference is nil or empty: ClusterRef")
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ClusterRef")
 		}
 		obj := &svcapitypes.Cluster{}
 		if err := getReferencedResourceState_Cluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return err
+			return hasReferences, err
 		}
 		ko.Spec.ClusterName = (*string)(obj.Spec.Name)
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Cluster looks up whether a referenced resource
@@ -193,26 +225,28 @@ func getReferencedResourceState_Cluster(
 
 // resolveReferenceForNodeRole reads the resource referenced
 // from NodeRoleRef field and sets the NodeRole
-// from referenced resource
-func resolveReferenceForNodeRole(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForNodeRole(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Nodegroup,
-) error {
+) (hasReferences bool, err error) {
 	if ko.Spec.NodeRoleRef != nil && ko.Spec.NodeRoleRef.From != nil {
+		hasReferences = true
 		arr := ko.Spec.NodeRoleRef.From
-		if arr == nil || arr.Name == nil || *arr.Name == "" {
-			return fmt.Errorf("provided resource reference is nil or empty: NodeRoleRef")
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: NodeRoleRef")
 		}
 		obj := &iamapitypes.Role{}
 		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return err
+			return hasReferences, err
 		}
 		ko.Spec.NodeRole = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Role looks up whether a referenced resource
@@ -268,35 +302,35 @@ func getReferencedResourceState_Role(
 
 // resolveReferenceForRemoteAccess_SourceSecurityGroups reads the resource referenced
 // from RemoteAccess.SourceSecurityGroupRefs field and sets the RemoteAccess.SourceSecurityGroups
-// from referenced resource
-func resolveReferenceForRemoteAccess_SourceSecurityGroups(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForRemoteAccess_SourceSecurityGroups(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Nodegroup,
-) error {
-	if ko.Spec.RemoteAccess == nil {
-		return nil
-	}
+) (hasReferences bool, err error) {
 	if ko.Spec.RemoteAccess != nil {
-		if len(ko.Spec.RemoteAccess.SourceSecurityGroupRefs) > 0 {
-			resolved1 := []*string{}
-			for _, iter1 := range ko.Spec.RemoteAccess.SourceSecurityGroupRefs {
-				arr := iter1.From
-				if arr == nil || arr.Name == nil || *arr.Name == "" {
-					return fmt.Errorf("provided resource reference is nil or empty: RemoteAccess.SourceSecurityGroupRefs")
+		for _, f0iter := range ko.Spec.RemoteAccess.SourceSecurityGroupRefs {
+			if f0iter != nil && f0iter.From != nil {
+				hasReferences = true
+				arr := f0iter.From
+				if arr.Name == nil || *arr.Name == "" {
+					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: RemoteAccess.SourceSecurityGroupRefs")
 				}
 				obj := &ec2apitypes.SecurityGroup{}
 				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-					return err
+					return hasReferences, err
 				}
-				resolved1 = append(resolved1, (*string)(obj.Status.ID))
+				if ko.Spec.RemoteAccess.SourceSecurityGroups == nil {
+					ko.Spec.RemoteAccess.SourceSecurityGroups = make([]*string, 0, 1)
+				}
+				ko.Spec.RemoteAccess.SourceSecurityGroups = append(ko.Spec.RemoteAccess.SourceSecurityGroups, (*string)(obj.Status.ID))
 			}
-			ko.Spec.RemoteAccess.SourceSecurityGroups = resolved1
 		}
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_SecurityGroup looks up whether a referenced resource
@@ -352,30 +386,33 @@ func getReferencedResourceState_SecurityGroup(
 
 // resolveReferenceForSubnets reads the resource referenced
 // from SubnetRefs field and sets the Subnets
-// from referenced resource
-func resolveReferenceForSubnets(
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSubnets(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Nodegroup,
-) error {
-	if len(ko.Spec.SubnetRefs) > 0 {
-		resolved0 := []*string{}
-		for _, iter0 := range ko.Spec.SubnetRefs {
-			arr := iter0.From
-			if arr == nil || arr.Name == nil || *arr.Name == "" {
-				return fmt.Errorf("provided resource reference is nil or empty: SubnetRefs")
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.SubnetRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SubnetRefs")
 			}
 			obj := &ec2apitypes.Subnet{}
 			if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-				return err
+				return hasReferences, err
 			}
-			resolved0 = append(resolved0, (*string)(obj.Status.SubnetID))
+			if ko.Spec.Subnets == nil {
+				ko.Spec.Subnets = make([]*string, 0, 1)
+			}
+			ko.Spec.Subnets = append(ko.Spec.Subnets, (*string)(obj.Status.SubnetID))
 		}
-		ko.Spec.Subnets = resolved0
 	}
 
-	return nil
+	return hasReferences, nil
 }
 
 // getReferencedResourceState_Subnet looks up whether a referenced resource


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

Issue #, if available:

Description of changes:
Implements - https://github.com/aws-controllers-k8s/runtime/pull/121
See - https://github.com/aws-controllers-k8s/code-generator/pull/435
See - https://github.com/aws-controllers-k8s/runtime/releases/tag/v0.26.0

This PR does nothing other than regenerate this controller with the latest version of the code-generator and uses the associated version of the controller runtime.
I have not tested this code, however no code changes have been made.

I tried to add a non-related feature and the code generator introduced these changes.  It made sense to try to merge in its own PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
