### PR TITLE
Update coredns addon version to 1.26 compatible

### DIFF
--- a/test/e2e/tests/test_addon.py
+++ b/test/e2e/tests/test_addon.py
@@ -40,7 +40,7 @@ def wait_for_addon_deleted(eks_client, cluster_name, addon_name):
 @pytest.fixture
 def coredns_addon(eks_client, simple_cluster) -> Tuple[k8s.CustomResourceReference, Dict]:
     addon_name = "coredns"
-    addon_version = "v1.8.7-eksbuild.3"
+    addon_version = "v1.9.3-eksbuild.3"
     configuration_values = json.dumps(
         {"resources": {"limits": {"memory": "64Mi"}, "requests": {"cpu": "10m", "memory": "64Mi"}}})
     resolve_conflicts = "OVERWRITE"


### PR DESCRIPTION
Description of changes:
The current main branch is failing tests with the following error message:
```
InvalidParameterException: Addon version specified is not supported
```

This pull request updates the tested coredns add-on version from the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
