### PR TITLE
`wait_for_cluster_deleted` when cleaning up test EKS clusters

### DIFF
--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@589f8349bf75a27b0f53602bda73f76f80a967c5
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@abc558ed87fb22dcf1e8d30d91317d9e2f4d091c

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -44,7 +44,7 @@ def wait_for_cluster_deleted(eks_client, cluster_name):
         name=cluster_name,
         WaiterConfig={
             'Delay': 30,
-            'MaxAttempts': 100,
+            'MaxAttempts': 40, # 20 minutes
         },
     )
 

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -38,6 +38,16 @@ def wait_for_cluster_active(eks_client, cluster_name):
     waiter = eks_client.get_waiter('cluster_active')
     waiter.wait(name=cluster_name)
 
+def wait_for_cluster_deleted(eks_client, cluster_name):
+    waiter = eks_client.get_waiter('cluster_deleted')
+    waiter.wait(
+        name=cluster_name,
+        WaiterConfig={
+            'Delay': 30,
+            'MaxAttempts': 100,
+        },
+    )
+
 def get_and_assert_status(ref: k8s.CustomResourceReference, expected_status: str, expected_synced: bool):
     cr = k8s.get_resource(ref)
     assert cr is not None
@@ -55,7 +65,7 @@ def eks_client():
     return boto3.client('eks')
 
 @pytest.fixture
-def simple_cluster():
+def simple_cluster(eks_client):
     cluster_name = random_suffix_name("simple-cluster", 32)
 
     replacements = REPLACEMENT_VALUES.copy()
@@ -84,6 +94,7 @@ def simple_cluster():
     try:
         _, deleted = k8s.delete_custom_resource(ref, 3, 10)
         assert deleted
+        wait_for_cluster_deleted(eks_client, cluster_name)
     except:
         pass
 
@@ -152,3 +163,4 @@ class TestCluster:
 
         # Delete the k8s resource on teardown of the module
         k8s.delete_custom_resource(ref)
+        wait_for_cluster_deleted(eks_client, cluster_name)


### PR DESCRIPTION
`wait_for_cluster_deleted` when cleaning up test EKS clusters.

Also, update the SHA for `acktest` upstream in order to bring in a fix from https://github.com/aws-controllers-k8s/test-infra/pull/361

Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1509

Description of changes:
Add the use of a boto3 `Waiter` to poll for cluster deletion before considering a test EKS cluster to be cleaned up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
