### PR TITLE
Introduce annotation to tweak `scalingConfig.desiredSize` control

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,38 @@ Kubernetes Github project.
 
 [ack-issues]: https://github.com/aws-controllers-k8s/community/issues
 
+## Getting started
+
+To install the `eks-controller` on your cluster, follow the the
+[installation][ack-install] instructions.
+
+Currently, the `eks-controller` is GA and supports the following resources:
+- `Cluster`
+- `Nodegroup`
+- `FargateProfile`
+- `Addon`
+- `PodIdentityAssociation`
+
+A detailed list of the resources supported specifications can be found in the
+[references][ack-references] section.
+
+## Annotations
+
+For some resources, the `eks-controller` supports annotations to customize the
+behavior of the controller. The following annotations are supported:
+
+- **Nodegroup**
+    - `eks.service.k8s.aws/desired-size-managed-by`: used to control whether the
+      controller should manage the desiredSize of the Nodegroup `spec.ScalingConfig.DesiredSize`.
+      It supports the following values:
+        - `ack-eks-controller`: If set the controller will be responsible for
+          managing the desired size of the nodegroup.
+        - `external-autoscaler`: If set will ignore any changes to the
+          `spec.ScalingConfig.DesiredSize` and will not manage the desired size
+          of the nodegroup.
+
+      If not set, the controller will default to `ack-eks-controller`.
+
 ## Contributing
 
 We welcome community contributions and pull requests.
@@ -24,3 +56,6 @@ You can also learn more about our [Governance](/GOVERNANCE.md) structure.
 ## License
 
 This project is [licensed](/LICENSE) under the Apache-2.0 License.
+
+[ack-references]:https://aws-controllers-k8s.github.io/community/reference
+[ack-install]:https://aws-controllers-k8s.github.io/community/docs/user-docs/install/

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-12-31T10:44:20Z"
-  build_hash: fc449014a4da40f91014bab2641a1bfe52d44a4e
+  build_date: "2024-01-02T04:11:25Z"
+  build_hash: 00e081fb541587f33970ad80c99f2ac02e9c2525
   go_version: go1.21.5
-  version: v0.28.0-6-gfc44901
+  version: v0.28.0-8-g00e081f
 api_directory_checksum: e3ab17e79de95c932895a4372c0b01e976aec4cb
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 680e56994fbb86d721a2fa17f67b7ebbe924d395
+  file_checksum: 95f5a8da41f547e5d9c7f207d5405b64ed866196
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-12-14T21:31:34Z"
-  build_hash: 1f16813c807af6889060b4ce7ded2a69dc027d8c
+  build_date: "2023-12-31T10:44:20Z"
+  build_hash: fc449014a4da40f91014bab2641a1bfe52d44a4e
   go_version: go1.21.5
-  version: v0.28.0
-api_directory_checksum: c243e9ab23c6b9038f6f6aebba5f0b34efafdf6a
+  version: v0.28.0-6-gfc44901
+api_directory_checksum: e3ab17e79de95c932895a4372c0b01e976aec4cb
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: 9b2af7d38552d1e11a320576c802f375dcba3a06
+  file_checksum: 680e56994fbb86d721a2fa17f67b7ebbe924d395
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package v1alpha1
 
 import "fmt"

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -1,0 +1,35 @@
+package v1alpha1
+
+import "fmt"
+
+var (
+	// DesiredSizeManagedByAnnotation is the annotation key used to set the management style for the
+	// desired size of a nodegroup scaling configuration. This annotation can only be set on a
+	// nodegroup custom resource.
+	//
+	// The value of this annotation must be one of the following:
+	//
+	// - 'external-autoscaler': The desired size is managed by an external entity. Causing the
+	//                          controller to completly ignore the `scalingConfig.desiredSize` field
+	// 						    and not reconcile the desired size of a nodegroup.
+	//
+	// - 'ack-eks-controller':  The desired size is managed by the ACK controller. Causing the
+	//                          controller to reconcile the desired size of the nodegroup with the
+	//                          value of the `spec.scalingConfig.desiredSize` field.
+	//
+	// By default the desired size is managed by the controller. If the annotation is not set, or
+	// the value is not one of the above, the controller will default to managing the desired size
+	// as if the annotation was set to "controller".
+	DesiredSizeManagedByAnnotation = fmt.Sprintf("%s/desired-size-managed-by", GroupVersion.Group)
+)
+
+const (
+	// DesiredSizeManagedByExternalAutoscaler is the value of the DesiredSizeManagedByAnnotation
+	// annotation that indicates that the desired size of a nodegroup is managed by an external
+	// autoscaler.
+	DesiredSizeManagedByExternalAutoscaler = "external-autoscaler"
+	// DesiredSizeManagedByACKController is the value of the DesiredSizeManagedByAnnotation
+	// annotation that indicates that the desired size of a nodegroup is managed by the ACK
+	// controller.
+	DesiredSizeManagedByACKController = "ack-eks-controller"
+)

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -171,9 +171,6 @@ resources:
       Taints:
         compare:
           is_ignored: true
-      ScalingConfig.DesiredSize:
-        compare:
-          is_ignored: true
     renames:
       operations:
         CreateNodegroup:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -171,6 +171,9 @@ resources:
       Taints:
         compare:
           is_ignored: true
+      ScalingConfig.DesiredSize:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateNodegroup:
@@ -202,6 +205,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
+      delta_post_compare:
+        code: customPostCompare(delta, a, b)
       sdk_create_post_set_output:
         template_path: hooks/nodegroup/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -171,9 +171,6 @@ resources:
       Taints:
         compare:
           is_ignored: true
-      ScalingConfig.DesiredSize:
-        compare:
-          is_ignored: true
     renames:
       operations:
         CreateNodegroup:

--- a/generator.yaml
+++ b/generator.yaml
@@ -171,6 +171,9 @@ resources:
       Taints:
         compare:
           is_ignored: true
+      ScalingConfig.DesiredSize:
+        compare:
+          is_ignored: true
     renames:
       operations:
         CreateNodegroup:
@@ -202,6 +205,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
+      delta_post_compare:
+        code: customPostCompare(delta, a, b)
       sdk_create_post_set_output:
         template_path: hooks/nodegroup/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -161,10 +161,10 @@ spec:
                               description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                               type: string
                             name:
-                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
                               type: string
                             uid:
-                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids'
                               type: string
                           required:
                           - apiVersion

--- a/pkg/resource/nodegroup/delta.go
+++ b/pkg/resource/nodegroup/delta.go
@@ -166,6 +166,13 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfig, b.ko.Spec.ScalingConfig) {
 		delta.Add("Spec.ScalingConfig", a.ko.Spec.ScalingConfig, b.ko.Spec.ScalingConfig)
 	} else if a.ko.Spec.ScalingConfig != nil && b.ko.Spec.ScalingConfig != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfig.DesiredSize, b.ko.Spec.ScalingConfig.DesiredSize) {
+			delta.Add("Spec.ScalingConfig.DesiredSize", a.ko.Spec.ScalingConfig.DesiredSize, b.ko.Spec.ScalingConfig.DesiredSize)
+		} else if a.ko.Spec.ScalingConfig.DesiredSize != nil && b.ko.Spec.ScalingConfig.DesiredSize != nil {
+			if *a.ko.Spec.ScalingConfig.DesiredSize != *b.ko.Spec.ScalingConfig.DesiredSize {
+				delta.Add("Spec.ScalingConfig.DesiredSize", a.ko.Spec.ScalingConfig.DesiredSize, b.ko.Spec.ScalingConfig.DesiredSize)
+			}
+		}
 		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfig.MaxSize, b.ko.Spec.ScalingConfig.MaxSize) {
 			delta.Add("Spec.ScalingConfig.MaxSize", a.ko.Spec.ScalingConfig.MaxSize, b.ko.Spec.ScalingConfig.MaxSize)
 		} else if a.ko.Spec.ScalingConfig.MaxSize != nil && b.ko.Spec.ScalingConfig.MaxSize != nil {

--- a/pkg/resource/nodegroup/delta.go
+++ b/pkg/resource/nodegroup/delta.go
@@ -166,13 +166,6 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfig, b.ko.Spec.ScalingConfig) {
 		delta.Add("Spec.ScalingConfig", a.ko.Spec.ScalingConfig, b.ko.Spec.ScalingConfig)
 	} else if a.ko.Spec.ScalingConfig != nil && b.ko.Spec.ScalingConfig != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfig.DesiredSize, b.ko.Spec.ScalingConfig.DesiredSize) {
-			delta.Add("Spec.ScalingConfig.DesiredSize", a.ko.Spec.ScalingConfig.DesiredSize, b.ko.Spec.ScalingConfig.DesiredSize)
-		} else if a.ko.Spec.ScalingConfig.DesiredSize != nil && b.ko.Spec.ScalingConfig.DesiredSize != nil {
-			if *a.ko.Spec.ScalingConfig.DesiredSize != *b.ko.Spec.ScalingConfig.DesiredSize {
-				delta.Add("Spec.ScalingConfig.DesiredSize", a.ko.Spec.ScalingConfig.DesiredSize, b.ko.Spec.ScalingConfig.DesiredSize)
-			}
-		}
 		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfig.MaxSize, b.ko.Spec.ScalingConfig.MaxSize) {
 			delta.Add("Spec.ScalingConfig.MaxSize", a.ko.Spec.ScalingConfig.MaxSize, b.ko.Spec.ScalingConfig.MaxSize)
 		} else if a.ko.Spec.ScalingConfig.MaxSize != nil && b.ko.Spec.ScalingConfig.MaxSize != nil {
@@ -227,5 +220,6 @@ func newResourceDelta(
 		}
 	}
 
+	customPostCompare(delta, a, b)
 	return delta
 }

--- a/pkg/resource/nodegroup/hook_test.go
+++ b/pkg/resource/nodegroup/hook_test.go
@@ -1,13 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package nodegroup
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
-	"github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws/aws-sdk-go/aws"
+	svcsdk "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 )
 
 func TestTaints(t *testing.T) {
@@ -21,7 +38,7 @@ func TestTaints(t *testing.T) {
 
 	a := &resource{
 		ko: &v1alpha1.Nodegroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "test",
 			},
@@ -44,7 +61,7 @@ func TestTaints(t *testing.T) {
 
 	b := &resource{
 		ko: &v1alpha1.Nodegroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "test",
 			},
@@ -73,7 +90,7 @@ func TestTaints(t *testing.T) {
 
 	b = &resource{
 		ko: &v1alpha1.Nodegroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "test",
 			},
@@ -102,7 +119,7 @@ func TestTaints(t *testing.T) {
 
 	b = &resource{
 		ko: &v1alpha1.Nodegroup{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "test",
 			},
@@ -131,4 +148,271 @@ func TestTaints(t *testing.T) {
 	delta = &ackcompare.Delta{}
 	customPreCompare(delta, a, b)
 	assert.True(t, delta.DifferentAt("Spec.Taints"), "Taints have different length")
+}
+
+func newScalingConfig(desired, max, min int64) *v1alpha1.NodegroupScalingConfig {
+	return &v1alpha1.NodegroupScalingConfig{
+		DesiredSize: aws.Int64(desired),
+		MaxSize:     aws.Int64(max),
+		MinSize:     aws.Int64(min),
+	}
+}
+
+func newNodegroupWithScalingConfig(desired, max, min int64) *v1alpha1.Nodegroup {
+	return &v1alpha1.Nodegroup{
+		Spec: v1alpha1.NodegroupSpec{
+			ScalingConfig: newScalingConfig(desired, max, min),
+		},
+	}
+}
+
+func newNodegroupScalingConfigManagedByExternalAutoscaler(desired, max, min int64) *v1alpha1.Nodegroup {
+	nodegroup := newNodegroupWithScalingConfig(desired, max, min)
+	nodegroup.ObjectMeta.SetAnnotations(map[string]string{
+		"eks.services.k8s.aws/desired-size-managed-by": "external-autoscaler",
+	})
+	return nodegroup
+}
+
+func Test_compareNodegroupScalingConfigs_ManagedByDefault(t *testing.T) {
+	type args struct {
+		a *v1alpha1.Nodegroup
+		b *v1alpha1.Nodegroup
+	}
+	tests := []struct {
+		name                       string
+		args                       args
+		expectDelta                bool
+		expectDeltaAtScalingConfig bool
+	}{
+		{
+			name: "non nil empty scaling config",
+			args: args{
+				a: newNodegroupWithScalingConfig(0, 0, 0),
+				b: newNodegroupWithScalingConfig(0, 0, 0),
+			},
+			expectDelta:                false,
+			expectDeltaAtScalingConfig: false,
+		},
+		{
+			name: "different scaling configurations",
+			args: args{
+				a: newNodegroupWithScalingConfig(2, 2, 2),
+				b: newNodegroupWithScalingConfig(1, 1, 1),
+			},
+			expectDelta:                true,
+			expectDeltaAtScalingConfig: true,
+		},
+		{
+			name: "different desired size",
+			args: args{
+				a: newNodegroupWithScalingConfig(2, 2, 2),
+				b: newNodegroupWithScalingConfig(1, 2, 2),
+			},
+			expectDelta:                true,
+			expectDeltaAtScalingConfig: true,
+		},
+		{
+			name: "different max/min size",
+			args: args{
+				a: newNodegroupWithScalingConfig(2, 2, 2),
+				b: newNodegroupWithScalingConfig(2, 1, 5),
+			},
+			expectDelta:                true,
+			expectDeltaAtScalingConfig: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delta := newResourceDelta(&resource{tt.args.a}, &resource{tt.args.b})
+			if tt.expectDelta != (len(delta.Differences) > 0) {
+				t.Errorf("customPostCompare() has delta = %v, want %v", delta, tt.expectDelta)
+			}
+			if tt.expectDeltaAtScalingConfig != delta.DifferentAt("Spec.ScalingConfig.DesiredSize") {
+				for _, diff := range delta.Differences {
+					fmt.Println("**diff:", diff.Path)
+				}
+				t.Errorf("customPostCompare() has delta at ScalingConfig = %v, want %v", delta, tt.expectDeltaAtScalingConfig)
+			}
+		})
+	}
+}
+
+func Test_compareNodegroupScalingConfigs_ManagedByExternal(t *testing.T) {
+	type args struct {
+		a *v1alpha1.Nodegroup
+		b *v1alpha1.Nodegroup
+	}
+	tests := []struct {
+		name                       string
+		args                       args
+		expectDelta                bool
+		expectDeltaAtScalingConfig bool
+	}{
+		{
+			name: "non nil empty scaling config",
+			args: args{
+				a: newNodegroupScalingConfigManagedByExternalAutoscaler(0, 0, 0),
+				b: newNodegroupScalingConfigManagedByExternalAutoscaler(0, 0, 0),
+			},
+			expectDelta:                false,
+			expectDeltaAtScalingConfig: false,
+		},
+		{
+			name: "different scaling configurations",
+			args: args{
+				a: newNodegroupScalingConfigManagedByExternalAutoscaler(2, 2, 2),
+				b: newNodegroupScalingConfigManagedByExternalAutoscaler(1, 1, 1),
+			},
+			expectDelta:                true,
+			expectDeltaAtScalingConfig: false,
+		},
+		{
+			name: "different desired size",
+			args: args{
+				a: newNodegroupScalingConfigManagedByExternalAutoscaler(2, 2, 2),
+				b: newNodegroupScalingConfigManagedByExternalAutoscaler(1, 2, 2),
+			},
+			expectDelta:                false,
+			expectDeltaAtScalingConfig: false,
+		},
+		{
+			name: "different max/min size",
+			args: args{
+				a: newNodegroupWithScalingConfig(2, 2, 2),
+				b: newNodegroupWithScalingConfig(2, 1, 5),
+			},
+			expectDelta:                true,
+			expectDeltaAtScalingConfig: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delta := newResourceDelta(&resource{tt.args.a}, &resource{tt.args.b})
+			if tt.expectDelta != (len(delta.Differences) > 0) {
+				t.Errorf("customPostCompare() has delta = %v, want %v", delta, tt.expectDelta)
+			}
+			if tt.expectDeltaAtScalingConfig != delta.DifferentAt("Spec.ScalingConfig.DesiredSize") {
+				t.Errorf("customPostCompare() has delta at ScalingConfig = %v, want %v", delta, tt.expectDeltaAtScalingConfig)
+			}
+		})
+	}
+}
+
+func newUpdateScalingConfigPayload(desired, max, min int64) *svcsdk.NodegroupScalingConfig {
+	return &svcsdk.NodegroupScalingConfig{
+		DesiredSize: aws.Int64(desired),
+		MaxSize:     aws.Int64(max),
+		MinSize:     aws.Int64(min),
+	}
+}
+
+func Test_resourceManager_newUpdateScalingConfigPayload_ManagedByExternalAutoscaler(t *testing.T) {
+	type args struct {
+		latest  *v1alpha1.Nodegroup
+		desired *v1alpha1.Nodegroup
+	}
+	tests := []struct {
+		name string
+		args args
+		want *svcsdk.NodegroupScalingConfig
+	}{
+		{
+			name: "no changes",
+			args: args{
+				latest:  newNodegroupScalingConfigManagedByExternalAutoscaler(2, 2, 2),
+				desired: newNodegroupScalingConfigManagedByExternalAutoscaler(2, 2, 2),
+			},
+			// In such a situation the request will never be sent to EKS, however we still wanna test the behaviour
+			// of the function.
+			want: newUpdateScalingConfigPayload(2, 2, 2),
+		},
+		{
+			name: "only desired size changed",
+			args: args{
+				desired: newNodegroupScalingConfigManagedByExternalAutoscaler(10, 2, 2),
+				latest:  newNodegroupScalingConfigManagedByExternalAutoscaler(2, 2, 2),
+			},
+			want: newUpdateScalingConfigPayload(2, 2, 2),
+		},
+		{
+			name: "all the fields changed",
+			args: args{
+				desired: newNodegroupScalingConfigManagedByExternalAutoscaler(20, 15, 20),
+				latest:  newNodegroupScalingConfigManagedByExternalAutoscaler(10, 10, 10),
+			},
+			want: newUpdateScalingConfigPayload(10, 15, 20),
+		},
+		{
+			name: "all the fields changed except desired size",
+			args: args{
+				desired: newNodegroupScalingConfigManagedByExternalAutoscaler(10, 15, 20),
+				latest:  newNodegroupScalingConfigManagedByExternalAutoscaler(10, 10, 10),
+			},
+			want: newUpdateScalingConfigPayload(10, 15, 20),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := resourceManager{}
+			if got := rm.newUpdateScalingConfigPayload(&resource{tt.args.desired}, &resource{tt.args.latest}); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resourceManager.newUpdateScalingConfigPayload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resourceManager_newUpdateScalingConfigPayload_ManagedByDefault(t *testing.T) {
+	type args struct {
+		latest  *v1alpha1.Nodegroup
+		desired *v1alpha1.Nodegroup
+	}
+	tests := []struct {
+		name string
+		args args
+		want *svcsdk.NodegroupScalingConfig
+	}{
+		{
+			name: "no changes",
+			args: args{
+				latest:  newNodegroupWithScalingConfig(2, 2, 2),
+				desired: newNodegroupWithScalingConfig(2, 2, 2),
+			},
+			// In such a situation the request will never be sent to EKS, however we still wanna test the behaviour
+			// of the function.
+			want: newUpdateScalingConfigPayload(2, 2, 2),
+		},
+		{
+			name: "only desired size changed",
+			args: args{
+				desired: newNodegroupWithScalingConfig(10, 2, 2),
+				latest:  newNodegroupWithScalingConfig(2, 2, 2),
+			},
+			want: newUpdateScalingConfigPayload(10, 2, 2),
+		},
+		{
+			name: "all the fields changed",
+			args: args{
+				desired: newNodegroupWithScalingConfig(20, 15, 20),
+				latest:  newNodegroupWithScalingConfig(10, 10, 10),
+			},
+			want: newUpdateScalingConfigPayload(20, 15, 20),
+		},
+		{
+			name: "all the fields changed except desired size",
+			args: args{
+				desired: newNodegroupWithScalingConfig(10, 15, 20),
+				latest:  newNodegroupWithScalingConfig(10, 10, 10),
+			},
+			want: newUpdateScalingConfigPayload(10, 15, 20),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := resourceManager{}
+			if got := rm.newUpdateScalingConfigPayload(&resource{tt.args.desired}, &resource{tt.args.latest}); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resourceManager.newUpdateScalingConfigPayload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Introduce Annotation for Dynamic Nodegroup `spec.ScalingConfig.desiredSize`
Control

This patch introduces a new annotation that allows flexible management of the
desired size for a nodegroup scaling configuration. The annotation,
`eks.services.k8s.aws/desired-size-managed-by`, can be set on a nodegroup custom
resource and specifies whether the desired size is managed externally by an
autoscaler or by the ACK controller.

The possible values for the annotation include 'external-autoscaler' and
'ack-eks-controller'. If the annotation is not set or has an invalid value, the
controller defaults to managing the desired size.

Adjustments are made to delta comparison logic, custom pre and post-compare
hooks, and the update configuration logic to ensure proper handling of the
desired size based on the annotation.

This enhancement provides flexibility in managing the desired size of a
nodegroup, allowing external entities or the ACK controller to control this
aspect.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
