### PR TITLE
Enhance `Nodegroup` documentation, logging and e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ For some resources, the `eks-controller` supports annotations to customize the
 behavior of the controller. The following annotations are supported:
 
 - **Nodegroup**
-    - `eks.service.k8s.aws/desired-size-managed-by`: used to control whether the
+    - `eks.services.k8s.aws/desired-size-managed-by`: used to control whether the
       controller should manage the desiredSize of the Nodegroup `spec.ScalingConfig.DesiredSize`.
       It supports the following values:
-        - `ack-eks-controller`: If set the controller will be responsible for
+        - `ack-eks-controller`: If set, the controller will be responsible for
           managing the desired size of the nodegroup.
-        - `external-autoscaler`: If set will ignore any changes to the
+        - `external-autoscaler`: If set, will ignore any changes to the
           `spec.ScalingConfig.DesiredSize` and will not manage the desired size
           of the nodegroup.
 

--- a/pkg/resource/nodegroup/hook_test.go
+++ b/pkg/resource/nodegroup/hook_test.go
@@ -15,6 +15,7 @@ package nodegroup
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/eks"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
 )
@@ -354,7 +356,11 @@ func Test_resourceManager_newUpdateScalingConfigPayload_ManagedByExternalAutosca
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rm := resourceManager{}
+			rm := resourceManager{
+				log: zap.New(zap.UseFlagOptions(&zap.Options{
+					DestWriter: io.Discard,
+				})),
+			}
 			if got := rm.newUpdateScalingConfigPayload(&resource{tt.args.desired}, &resource{tt.args.latest}); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("resourceManager.newUpdateScalingConfigPayload() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Issue N/A

Description of changes:
- Fix a crucial "typo" in the `Nodegroup` annotations docs
- Add some more logging to help debugging the controller behaviour when
  dealing with the `desired-size-managed-by` annotation
- Add some e2e tests to simulate the "existence" of an external autoscaler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
