### PR TITLE
Support tweaking `NodeGroupVersion` update requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently, the `eks-controller` is GA and supports the following resources:
 - `FargateProfile`
 - `Addon`
 - `PodIdentityAssociation`
+- `AccessEntry`
 
 A detailed list of the resources supported specifications can be found in the
 [references][ack-references] section.
@@ -39,6 +40,11 @@ behavior of the controller. The following annotations are supported:
           of the nodegroup.
 
       If not set, the controller will default to `ack-eks-controller`.
+
+    - `eks.services.k8s.aws/force-update-version`: used to force the version
+      update of the nodegroup. If set to `true`, and the controller detects a
+      a change in the nodegroup, it will set the `force` attribute to `true`
+      in the `UpdateNodeGroupConfig` API call.
 
 ## Contributing
 

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -34,6 +34,13 @@ var (
 	// the value is not one of the above, the controller will default to managing the desired size
 	// as if the annotation was set to "controller".
 	DesiredSizeManagedByAnnotation = fmt.Sprintf("%s/desired-size-managed-by", GroupVersion.Group)
+	// ForceNodeGroupUpdateVersionAnnotation is the annotation key used to force an update of the
+	// nodegroup version. This annotation can only be set on a nodegroup custom resource.
+	// The value of this annotation must be a boolean value. If the value is "true", the controller
+	// will force an update of the nodegroup version to the value specified in the `version` field
+	// of the `spec` object. If the value is "false", the controller will not force an update of the
+	// nodegroup version.
+	ForceNodeGroupUpdateVersionAnnotation = fmt.Sprintf("%s/force-update-version", GroupVersion.Group)
 )
 
 const (


### PR DESCRIPTION
Prior to this patch, the eks-controller wasn't able to set the
ReleaseVersion, LaunchTemplate or the force attribute when making
an `UpdateNodeGroupVersion` API Call.

This patch correctly sets the ReleaseVersion and LaunchTemplate in the
API request, and introduces a new annotation allowing users to set the
Force attribute to true.

We're adding a new annotation
`eks.services.k8s.aws/force-update-version` - when set to true, the
controller will toggle the Force boolean in the update request.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
