### PR TITLE
Correctly retrieve the ARN for `PodIdentityAssociation`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-02-02T21:52:26Z"
+  build_date: "2024-02-03T01:09:21Z"
   build_hash: 5b4565ec2712d29988b8123aeeed6a4af57467bf
   go_version: go1.21.5
   version: v0.29.2-4-g5b4565e
-api_directory_checksum: 27de3ee9e8abc019380507b219d0192bff16ea95
+api_directory_checksum: d960a9f06b58cc445e5ab21fb26ee6d92c441374
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.13
 generator_config_info:
-  file_checksum: 29e2afabc0392d05503834dc17c4fafb24b582e5
+  file_checksum: 7473dd4afcf1e30d99f20e77cbad94e2df5c7093
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -2,7 +2,7 @@ resources:
   Addon:
     hooks:
       sdk_update_pre_build_request:
-        template_path: hooks/pod_identity_association/sdk_update_pre_build_request.go.tpl
+        template_path: hooks/addons/sdk_update_pre_build_request.go.tpl
     fields:
       ClusterName:
         references:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/eks-controller
-  newTag: 1.2.2
+  newTag: 1.2.3

--- a/generator.yaml
+++ b/generator.yaml
@@ -2,7 +2,7 @@ resources:
   Addon:
     hooks:
       sdk_update_pre_build_request:
-        template_path: hooks/pod_identity_association/sdk_update_pre_build_request.go.tpl
+        template_path: hooks/addons/sdk_update_pre_build_request.go.tpl
     fields:
       ClusterName:
         references:

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: eks-chart
 description: A Helm chart for the ACK service controller for Amazon Elastic Kubernetes Service (EKS)
-version: 1.2.2
-appVersion: 1.2.2
+version: 1.2.3
+appVersion: 1.2.3
 home: https://github.com/aws-controllers-k8s/eks-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/eks-controller:1.2.2".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/eks-controller:1.2.3".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/eks-controller
-  tag: 1.2.2
+  tag: 1.2.3
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/pod_identity_association/sdk.go
+++ b/pkg/resource/pod_identity_association/sdk.go
@@ -313,9 +313,17 @@ func (rm *resourceManager) sdkUpdate(
 		exit(err)
 	}()
 	if delta.DifferentAt("Spec.Tags") {
+		// TODO(a-hilaly) we need to switch to "ONLY" using the ARN from the ackResourceMetadata
+		// in the future.
+		resourceARN := ""
+		if desired.ko.Status.ACKResourceMetadata.ARN != nil {
+			resourceARN = *latest.ko.Status.AssociationARN
+		} else if desired.ko.Status.AssociationARN != nil {
+			resourceARN = string(*latest.ko.Status.ACKResourceMetadata.ARN)
+		}
 		err := syncTags(
 			ctx, rm.sdkapi, rm.metrics,
-			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			resourceARN,
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		)
 		if err != nil {

--- a/templates/hooks/pod_identity_association/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/pod_identity_association/sdk_update_pre_build_request.go.tpl
@@ -1,7 +1,15 @@
 	if delta.DifferentAt("Spec.Tags") {
+		// TODO(a-hilaly) we need to switch to "ONLY" using the ARN from the ackResourceMetadata
+		// in the future.
+		resourceARN := ""
+		if desired.ko.Status.ACKResourceMetadata.ARN != nil {
+			resourceARN = *latest.ko.Status.AssociationARN
+		} else if desired.ko.Status.AssociationARN != nil{
+			resourceARN = string(*latest.ko.Status.ACKResourceMetadata.ARN)
+		}
 		err := syncTags(
-			ctx, rm.sdkapi, rm.metrics, 
-			string(*desired.ko.Status.ACKResourceMetadata.ARN), 
+			ctx, rm.sdkapi, rm.metrics,
+			resourceARN,
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		)
 		if err != nil {


### PR DESCRIPTION
In the previous patch, we added tag update support to all EKS resources.
In the process, we also began populating the PIA resource ARN in the
`ackResourcemetadata` field. The tag update logic, assumed that all
resouces would have an ARN in the `ackResourceMetadata`, which is not
the case for old resources (created by an eks-controller < 1.2.2).

This patch correctly retrieves the ARN from the appropriate location.
All old resources will have their ARN directly popualted in
`ackResourceMetadata` once the controller reconciles.

This patch also publishes `v1.2.3` release manifests

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
