### PR TITLE
Refine update patterns for `Cluster` and `Nodegroup` resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-02-03T01:09:21Z"
+  build_date: "2024-02-08T04:09:29Z"
   build_hash: 5b4565ec2712d29988b8123aeeed6a4af57467bf
   go_version: go1.21.5
   version: v0.29.2-4-g5b4565e
@@ -7,7 +7,7 @@ api_directory_checksum: d960a9f06b58cc445e5ab21fb26ee6d92c441374
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.13
 generator_config_info:
-  file_checksum: 7473dd4afcf1e30d99f20e77cbad94e2df5c7093
+  file_checksum: 89a00ff29a62ca0e86a8c08b275a6e9e708004b0
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -232,6 +232,11 @@ resources:
           service_name: iam
           resource: Role
           path: Status.ACKResourceMetadata.ARN
+        is_immutable: true
+      DiskSize:
+        is_immutable: true
+      RemoteAccess:
+        is_immutable: true
       RemoteAccess.SourceSecurityGroups:
         references:
           service_name: ec2
@@ -242,7 +247,14 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+        is_immutable: true
       Taints:
+        compare:
+          is_ignored: true
+      ReleaseVersion:
+        compare:
+          is_ignored: true
+      Version:
         compare:
           is_ignored: true
     renames:

--- a/generator.yaml
+++ b/generator.yaml
@@ -232,6 +232,11 @@ resources:
           service_name: iam
           resource: Role
           path: Status.ACKResourceMetadata.ARN
+        is_immutable: true
+      DiskSize:
+        is_immutable: true
+      RemoteAccess:
+        is_immutable: true
       RemoteAccess.SourceSecurityGroups:
         references:
           service_name: ec2
@@ -242,7 +247,14 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+        is_immutable: true
       Taints:
+        compare:
+          is_ignored: true
+      ReleaseVersion:
+        compare:
+          is_ignored: true
+      Version:
         compare:
           is_ignored: true
     renames:

--- a/pkg/resource/nodegroup/delta.go
+++ b/pkg/resource/nodegroup/delta.go
@@ -138,13 +138,6 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.NodeRoleRef, b.ko.Spec.NodeRoleRef) {
 		delta.Add("Spec.NodeRoleRef", a.ko.Spec.NodeRoleRef, b.ko.Spec.NodeRoleRef)
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.ReleaseVersion, b.ko.Spec.ReleaseVersion) {
-		delta.Add("Spec.ReleaseVersion", a.ko.Spec.ReleaseVersion, b.ko.Spec.ReleaseVersion)
-	} else if a.ko.Spec.ReleaseVersion != nil && b.ko.Spec.ReleaseVersion != nil {
-		if *a.ko.Spec.ReleaseVersion != *b.ko.Spec.ReleaseVersion {
-			delta.Add("Spec.ReleaseVersion", a.ko.Spec.ReleaseVersion, b.ko.Spec.ReleaseVersion)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.RemoteAccess, b.ko.Spec.RemoteAccess) {
 		delta.Add("Spec.RemoteAccess", a.ko.Spec.RemoteAccess, b.ko.Spec.RemoteAccess)
 	} else if a.ko.Spec.RemoteAccess != nil && b.ko.Spec.RemoteAccess != nil {
@@ -217,13 +210,6 @@ func newResourceDelta(
 			if *a.ko.Spec.UpdateConfig.MaxUnavailablePercentage != *b.ko.Spec.UpdateConfig.MaxUnavailablePercentage {
 				delta.Add("Spec.UpdateConfig.MaxUnavailablePercentage", a.ko.Spec.UpdateConfig.MaxUnavailablePercentage, b.ko.Spec.UpdateConfig.MaxUnavailablePercentage)
 			}
-		}
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.Version, b.ko.Spec.Version) {
-		delta.Add("Spec.Version", a.ko.Spec.Version, b.ko.Spec.Version)
-	} else if a.ko.Spec.Version != nil && b.ko.Spec.Version != nil {
-		if *a.ko.Spec.Version != *b.ko.Spec.Version {
-			delta.Add("Spec.Version", a.ko.Spec.Version, b.ko.Spec.Version)
 		}
 	}
 

--- a/pkg/resource/nodegroup/hook_test.go
+++ b/pkg/resource/nodegroup/hook_test.go
@@ -424,6 +424,10 @@ func Test_resourceManager_newUpdateScalingConfigPayload_ManagedByDefault(t *test
 }
 
 func Test_newUpdateNodegroupPayload(t *testing.T) {
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.Version", nil, nil)
+	delta.Add("Spec.LaunchTemplate", nil, nil)
+
 	type args struct {
 		r *resource
 	}
@@ -511,7 +515,7 @@ func Test_newUpdateNodegroupPayload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newUpdateNodegroupVersionPayload(tt.args.r)
+			got := newUpdateNodegroupVersionPayload(delta, tt.args.r)
 			assert.Equal(t, tt.wantVersion, *got.Version)
 			if tt.wantForce {
 				assert.NotNil(t, got.Force)

--- a/pkg/resource/nodegroup/sdk.go
+++ b/pkg/resource/nodegroup/sdk.go
@@ -962,6 +962,27 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	}
 }
 
+// getImmutableFieldChanges returns list of immutable fields from the
+func (rm *resourceManager) getImmutableFieldChanges(
+	delta *ackcompare.Delta,
+) []string {
+	var fields []string
+	if delta.DifferentAt("Spec.DiskSize") {
+		fields = append(fields, "DiskSize")
+	}
+	if delta.DifferentAt("Spec.NodeRole") {
+		fields = append(fields, "NodeRole")
+	}
+	if delta.DifferentAt("Spec.RemoteAccess") {
+		fields = append(fields, "RemoteAccess")
+	}
+	if delta.DifferentAt("Spec.Subnets") {
+		fields = append(fields, "Subnets")
+	}
+
+	return fields
+}
+
 // newNodegroupScalingConfig returns a NodegroupScalingConfig object
 // with each the field set by the resource's corresponding spec field.
 func (rm *resourceManager) newNodegroupScalingConfig(

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// NOTE(a-hilaly): We can generalize this function and port it to the aws-controllers-k8s/pkg repository.
+// we could also consider importing a SemVer/Upstream library to help us with utility - just keeping things
+// simple now + we need some ATTRIBUTION.md generation automation
+
+var (
+	// ErrInvalidEKSKubernetesVersion is an error that is returned when the given EKS kubernetes version is invalid.
+	ErrInvalidEKSKubernetesVersion = fmt.Errorf("invalid EKS kubernetes version")
+	// ErrInvalidEKSKubernetesReleaseVersion is an error that is returned when the given EKS kubernetes release version is invalid.
+	ErrInvalidEKSKubernetesReleaseVersion = fmt.Errorf("invalid EKS kubernetes release version")
+)
+
+// IncrementVersionMajor increments the minor version of the given EKS kubernetes version
+// and returns the new version. It returns an error if the given version is not in the
+// expected format.
+//
+// For example, given "1.16", it returns "1.17"
+func IncrementEKSMinorVersion(version string) (string, error) {
+	major, minor, err := parseEKSKubernetesVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse EKS kubernetes version: %w", err)
+	}
+
+	return fmt.Sprintf("%d.%d", major, minor+1), nil
+}
+
+// GetEKSVersionFromReleaseVersion returns the EKS kubernetes version from the given release version.
+// It returns an error if the given version is not in the expected format.
+//
+// For example, given "1.16.8-01012024", it returns "1.16"
+func GetEKSVersionFromReleaseVersion(version string) (string, error) {
+	// First, we split the version into the kubernetes version and the release version.
+	parts := strings.Split(version, "-")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("%w: %s: expected a version of format major.minor.patch-release", ErrInvalidEKSKubernetesReleaseVersion, version)
+	}
+
+	kubernetesVersion := parts[0]
+
+	// Then, we split the kubernetes version into its parts.
+	parts = strings.Split(kubernetesVersion, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", fmt.Errorf("invalid release version: %s", version)
+	}
+	return fmt.Sprintf("%s.%s", parts[0], parts[1]), nil
+}
+
+// CompareEKSKubernetesVersions compares two EKS kubernetes versions and returns 0 if they are equal,
+// -1 if version1 is less than version2, and 1 if version1 is greater than version2. It returns an
+// error if the given versions are not in the expected format.
+func CompareEKSKubernetesVersions(version1, version2 string) (int, error) {
+	majorVersion1, minorVersion1, err := parseEKSKubernetesVersion(version1)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse EKS kubernetes version: %w", err)
+	}
+	majorVersion2, minorVersion2, err := parseEKSKubernetesVersion(version2)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse EKS kubernetes version: %w", err)
+	}
+
+	// 1.9 < 2.0
+	if majorVersion1 < majorVersion2 {
+		return -1, nil
+	}
+	// 2.0 > 1.9
+	if majorVersion1 > majorVersion2 {
+		return 1, nil
+	}
+	// 1.9 < 1.17
+	if minorVersion1 < minorVersion2 {
+		return -1, nil
+	}
+	// 1.17 > 1.9
+	if minorVersion1 > minorVersion2 {
+		return 1, nil
+	}
+	return 0, nil
+}
+
+// parseEKSKubernetesVersion parses the given EKS kubernetes version and returns the major and minor versions.
+// It returns an error if the given version is not in the EKS version format (major.minor).
+func parseEKSKubernetesVersion(version string) (int, int, error) {
+	// First, we split the version into its parts
+	parts := strings.Split(version, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return 0, 0, fmt.Errorf("%w: %s: expected a version of format major.minor", ErrInvalidEKSKubernetesVersion, version)
+	}
+
+	// Then, we convert the parts to integers
+	majorVersion := parts[0]
+	minorVersion := parts[1]
+
+	majorVersionInteger, err := strconv.Atoi(majorVersion)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse minor version: %w", err)
+	}
+	minorVersionInteger, err := strconv.Atoi(minorVersion)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse minor version: %w", err)
+	}
+
+	if majorVersionInteger < 0 || minorVersionInteger < 0 {
+		return 0, 0, fmt.Errorf("%w: %s: expected positive integers", ErrInvalidEKSKubernetesVersion, version)
+	}
+	return majorVersionInteger, minorVersionInteger, nil
+}

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -1,0 +1,296 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import "testing"
+
+func TestIncrementEKSMinorVersion(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			args{version: ""},
+			"",
+			true,
+		},
+		{
+			"invalid version - no minor",
+			args{version: "1."},
+			"",
+			true,
+		},
+		{
+			"invalid version - no major",
+			args{version: ".16"},
+			"",
+			true,
+		},
+		{
+			"invalid version - no major and minor",
+			args{version: "."},
+			"",
+			true,
+		},
+		{
+			"invalid version - patch versions",
+			args{version: "1.16.8"},
+			"",
+			true,
+		},
+		{
+			"valid version - one digit",
+			args{version: "1.0"},
+			"1.1",
+			false,
+		},
+		{
+			"valid version - 2 digits",
+			args{version: "1.16"},
+			"1.17",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IncrementEKSMinorVersion(tt.args.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IncrementEKSMinorVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IncrementEKSMinorVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEKSVersionFromReleaseVersion(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"empty string",
+			args{version: ""},
+			"",
+			true,
+		},
+		{
+			"invalid version - minor",
+			args{version: "1."},
+			"",
+			true,
+		},
+		{
+			"invalid version - no patch",
+			args{version: "1.16."},
+			"",
+			true,
+		},
+		{
+			"invalid version - no release date",
+			args{version: "1.16.8-"},
+			"",
+			true,
+		},
+		{
+			"valid version",
+			args{version: "1.16.8-01012024"},
+			"1.16",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetEKSVersionFromReleaseVersion(tt.args.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetEKSVersionFromReleaseVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetEKSVersionFromReleaseVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareEKSKubernetesVersions(t *testing.T) {
+	type args struct {
+		version1 string
+		version2 string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			"empty string",
+			args{version1: "", version2: ""},
+			0,
+			true,
+		},
+		{
+			"invalid version - no minor",
+			args{version1: "1.", version2: "1.16"},
+			0,
+			true,
+		},
+		{
+			"invalid version - no major",
+			args{version1: ".16", version2: "1.16"},
+			0,
+			true,
+		},
+		{
+			"invalid version - no major and minor",
+			args{version1: ".", version2: "1.16"},
+			0,
+			true,
+		},
+		{
+			"invalid version - patch versions",
+			args{version1: "1.16.8", version2: "1.16"},
+			0,
+			true,
+		},
+		{
+			"valid version - equal",
+			args{version1: "1.16", version2: "1.16"},
+			0,
+			false,
+		},
+		{
+			"valid version - version1 < version2",
+			args{version1: "1.16", version2: "1.17"},
+			-1,
+			false,
+		},
+		{
+			"valid version - version1 > version2",
+			args{version1: "1.17", version2: "1.16"},
+			1,
+			false,
+		},
+		{
+			"valid version - major version1 < major version2",
+			args{version1: "1.16", version2: "2.0"},
+			-1,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CompareEKSKubernetesVersions(tt.args.version1, tt.args.version2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CompareEKSKubernetesVersions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CompareEKSKubernetesVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseEKSKubernetesVersion(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		want1   int
+		wantErr bool
+	}{
+		{
+			"empty string",
+			args{version: ""},
+			0,
+			0,
+			true,
+		},
+		{
+			"invalid version - no minor",
+			args{version: "1."},
+			0,
+			0,
+			true,
+		},
+		{
+			"invalid version - no major",
+			args{version: ".16"},
+			0,
+			0,
+			true,
+		},
+		{
+			"invalid version - no major and minor",
+			args{version: "."},
+			0,
+			0,
+			true,
+		},
+		{
+			"invalid version - patch versions",
+			args{version: "1.16.8"},
+			0,
+			0,
+			true,
+		},
+		{
+			"invalid version - negative major",
+			args{version: "-1.16"},
+			0,
+			0,
+			true,
+		},
+		{
+			"valid version",
+			args{version: "1.16"},
+			1,
+			16,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := parseEKSKubernetesVersion(tt.args.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseEKSKubernetesVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseEKSKubernetesVersion() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("parseEKSKubernetesVersion() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/test/e2e/common/__init__.py
+++ b/test/e2e/common/__init__.py
@@ -1,0 +1,8 @@
+# Ideally this should be a programatically resolved value, but it's not clear
+# how to do that. 
+TESTS_DEFAULT_KUBERNETES_VERSION_1_29 = '1.29'
+TESTS_DEFAULT_KUBERNETES_VERSION_1_28 = '1.28'
+TESTS_DEFAULT_KUBERNETES_VERSION_1_27 = '1.27'
+# This is a release version that will be used with 1.29 Nodegroups.
+TESTS_DEFAULT_KUBERNETES_RELEASE_VERSION_1_29 = '1.29.0-20240202'
+TESTS_DEFAULT_KUBERNETES_RELEASE_VERSION_1_28 = '1.28.5-20240202'

--- a/test/e2e/resources/cluster_simple.yaml
+++ b/test/e2e/resources/cluster_simple.yaml
@@ -7,6 +7,7 @@ spec:
   roleARN: $CLUSTER_ROLE
   accessConfig:
     authenticationMode: $AUTHENTICATION_MODE
+  version: "$K8S_VERSION"
   resourcesVPCConfig:
     endpointPrivateAccess: true
     endpointPublicAccess: true

--- a/test/e2e/resources/nodegroup_simple.yaml
+++ b/test/e2e/resources/nodegroup_simple.yaml
@@ -13,3 +13,5 @@ spec:
     minSize: 1
     maxSize: 1
     desiredSize: 1
+  version: "$K8S_VERSION"
+  releaseVersion: "$RELEASE_VERSION"


### PR DESCRIPTION
Prior to this patch, we observed that there was some missing logic for
handling `Cluster` and `Nodegroup` updates, especially when dealing with
version upgrades - making it a painful/incomplete UX when using the
eks-controller.

This commit enhances the logic for managing updates and upgrades of
cluster and nodegroups resources, enabling users to experience a better
declarative resource model. Here's what the controller can do now:

`Cluster` resources:
- Introduces `Cluster` version rolling update, allowing users to specify
  any version higher than the "current" one, even if the EKS API doesn't
  allow it. The controller will incrementally upgrade the the cluster
  version until it reaches the desired state. e.g `1.25` -> `1.29`

`Nodegroup` resources:
- Allows updates for `ReleaseVersion` and `LaunchTemplate`
- Enhances the delta/comparison logic for both `Version` and
  `ReleaseVersion` fields.
- Carefully crafts the `UpdateNodeGroupVersion` API input to avoid
  situations where the controller/resource can get trapped in a infinite
  update loop (`1.27` -> `1.28` -> `1.27`)
- Set `DiskSize`, `RemoteAccess`, `NodeRole` and `Subnets` as immutable
  fields

Additionally this commit is also adding e2e tests for the features/bug
fixes mentioned above

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
