### PR TITLE
Enhance EKS `AccessEntries` policy attachements and delta logic

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-02-08T16:38:43Z"
+  build_date: "2024-02-09T21:18:38Z"
   build_hash: 5b4565ec2712d29988b8123aeeed6a4af57467bf
   go_version: go1.21.5
   version: v0.29.2-4-g5b4565e
@@ -7,7 +7,7 @@ api_directory_checksum: d960a9f06b58cc445e5ab21fb26ee6d92c441374
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.13
 generator_config_info:
-  file_checksum: 89a00ff29a62ca0e86a8c08b275a6e9e708004b0
+  file_checksum: ac8c0c6f258d7b552ccbaf81401e6c511de3373e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -395,11 +395,15 @@ resources:
       AccessPolicies:
         custom_field:
           list_of: AssociateAccessPolicyInput
+        compare:
+          is_ignored: true
       AccessPolicies.AccessScope.Type:
         go_tag: json:"type,omitempty"
       Type:
         go_tag: json:"type,omitempty"
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/access_entry/sdk_read_one_post_set_output.go.tpl
       sdk_update_pre_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -395,11 +395,15 @@ resources:
       AccessPolicies:
         custom_field:
           list_of: AssociateAccessPolicyInput
+        compare:
+          is_ignored: true
       AccessPolicies.AccessScope.Type:
         go_tag: json:"type,omitempty"
       Type:
         go_tag: json:"type,omitempty"
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_read_one_post_set_output:
         template_path: hooks/access_entry/sdk_read_one_post_set_output.go.tpl
       sdk_update_pre_build_request:

--- a/pkg/resource/access_entry/delta.go
+++ b/pkg/resource/access_entry/delta.go
@@ -42,14 +42,8 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
-	if len(a.ko.Spec.AccessPolicies) != len(b.ko.Spec.AccessPolicies) {
-		delta.Add("Spec.AccessPolicies", a.ko.Spec.AccessPolicies, b.ko.Spec.AccessPolicies)
-	} else if len(a.ko.Spec.AccessPolicies) > 0 {
-		if !reflect.DeepEqual(a.ko.Spec.AccessPolicies, b.ko.Spec.AccessPolicies) {
-			delta.Add("Spec.AccessPolicies", a.ko.Spec.AccessPolicies, b.ko.Spec.AccessPolicies)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ClusterName, b.ko.Spec.ClusterName) {
 		delta.Add("Spec.ClusterName", a.ko.Spec.ClusterName, b.ko.Spec.ClusterName)
 	} else if a.ko.Spec.ClusterName != nil && b.ko.Spec.ClusterName != nil {

--- a/pkg/resource/access_entry/hooks_test.go
+++ b/pkg/resource/access_entry/hooks_test.go
@@ -1,0 +1,207 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package access_entry
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func Test_computeAccessPoliciesDelta(t *testing.T) {
+	type args struct {
+		desired []*v1alpha1.AssociateAccessPolicyInput
+		latest  []*v1alpha1.AssociateAccessPolicyInput
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantToAdd    []*v1alpha1.AssociateAccessPolicyInput
+		wantToDelete []*string
+	}{
+		{
+			name: "nil arrays",
+			args: args{
+				desired: nil,
+				latest:  nil,
+			},
+			wantToAdd:    nil,
+			wantToDelete: nil,
+		},
+		{
+			name: "empty/nil mixed arrays",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{},
+				latest:  nil,
+			},
+			wantToAdd:    nil,
+			wantToDelete: nil,
+		},
+		{
+			name: "nil/empty mixed arrays",
+			args: args{
+				desired: nil,
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{},
+			},
+			wantToAdd:    nil,
+			wantToDelete: nil,
+		},
+		{
+			name: "empty arrays",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{},
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{},
+			},
+			wantToAdd:    nil,
+			wantToDelete: nil,
+		},
+		{
+			name: "different sizes - to add",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1")}},
+				latest:  nil,
+			},
+			wantToAdd: []*v1alpha1.AssociateAccessPolicyInput{
+				{PolicyARN: aws.String("policy-arn-1")},
+			},
+			wantToDelete: nil,
+		},
+		{
+			name: "different sizes - to delete",
+			args: args{
+				desired: nil,
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1")}},
+			},
+			wantToDelete: []*string{aws.String("policy-arn-1")},
+		},
+		{
+			name: "equal sizes - one element - not equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1")}},
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-2")}},
+			},
+			wantToAdd: []*v1alpha1.AssociateAccessPolicyInput{
+				{PolicyARN: aws.String("policy-arn-1")},
+			},
+			wantToDelete: []*string{aws.String("policy-arn-2")},
+		},
+		{
+			name: "equal sizes - one simple element - equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1")}},
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1")}},
+			},
+		},
+		{
+			name: "equal sizes - one full element - equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}}},
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}}},
+			},
+		},
+		{
+			name: "equal sizes - nil/empty elements - equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String(""), Namespaces: []*string{aws.String("ns-1")}}}},
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: nil, Namespaces: []*string{aws.String("ns-1")}}}},
+			},
+		},
+		{
+			name: "equal sizes - nil/empty elements - equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String(""), Namespaces: nil}}},
+				latest:  []*v1alpha1.AssociateAccessPolicyInput{{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: nil, Namespaces: []*string{}}}},
+			},
+		},
+		{
+			name: "equal sizes - multiple elements - equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{
+					{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-2"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: []*string{}}},
+					{PolicyARN: aws.String("policy-arn-3"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-3"), Namespaces: nil}},
+				},
+				latest: []*v1alpha1.AssociateAccessPolicyInput{
+					{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-2"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: nil}},
+					{PolicyARN: aws.String("policy-arn-3"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-3"), Namespaces: []*string{}}},
+				},
+			},
+		},
+		{
+			name: "complex case - multiple elements - not equal",
+			args: args{
+				desired: []*v1alpha1.AssociateAccessPolicyInput{
+					// No-Op Policies
+					{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-2"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: []*string{}}},
+					{PolicyARN: aws.String("policy-arn-3"), AccessScope: &v1alpha1.AccessScope{Type: nil, Namespaces: nil}},
+					{PolicyARN: aws.String("policy-arn-4"), AccessScope: &v1alpha1.AccessScope{Type: aws.String(""), Namespaces: nil}},
+					// Policies to update (add/remove)
+					{PolicyARN: aws.String("policy-arn-5"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-6"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: []*string{aws.String("ns-2")}}},
+					{PolicyARN: aws.String("policy-arn-7"), AccessScope: &v1alpha1.AccessScope{Type: nil, Namespaces: nil}},
+					{PolicyARN: aws.String("policy-arn-8"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-10"), Namespaces: nil}},
+					// Policies to add (add only)
+					{PolicyARN: aws.String("policy-arn-9"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+				},
+				latest: []*v1alpha1.AssociateAccessPolicyInput{
+					{PolicyARN: aws.String("policy-arn-1"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-2"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: nil}},
+					{PolicyARN: aws.String("policy-arn-3"), AccessScope: &v1alpha1.AccessScope{Type: aws.String(""), Namespaces: []*string{}}},
+					{PolicyARN: aws.String("policy-arn-4"), AccessScope: &v1alpha1.AccessScope{Type: aws.String(""), Namespaces: nil}},
+					// Policies to update (add/remove)
+					{PolicyARN: aws.String("policy-arn-5"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1"), aws.String("ns-2"), aws.String("ns-3")}}},
+					{PolicyARN: aws.String("policy-arn-6"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-7"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-3"), Namespaces: []*string{aws.String("ns-1")}}},
+					{PolicyARN: aws.String("policy-arn-8"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-11"), Namespaces: nil}},
+					// Policies to be removed
+					{PolicyARN: aws.String("policy-arn-10"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+				},
+			},
+			wantToAdd: []*v1alpha1.AssociateAccessPolicyInput{
+				{PolicyARN: aws.String("policy-arn-5"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+				{PolicyARN: aws.String("policy-arn-6"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-2"), Namespaces: []*string{aws.String("ns-2")}}},
+				{PolicyARN: aws.String("policy-arn-7"), AccessScope: &v1alpha1.AccessScope{Type: nil, Namespaces: nil}},
+				{PolicyARN: aws.String("policy-arn-8"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-10"), Namespaces: nil}},
+				{PolicyARN: aws.String("policy-arn-9"), AccessScope: &v1alpha1.AccessScope{Type: aws.String("type-1"), Namespaces: []*string{aws.String("ns-1")}}},
+			},
+			wantToDelete: []*string{
+				aws.String("policy-arn-5"),
+				aws.String("policy-arn-6"),
+				aws.String("policy-arn-7"),
+				aws.String("policy-arn-8"),
+				aws.String("policy-arn-10"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotToAdd, gotToDelete := computeAccessPoliciesDelta(tt.args.desired, tt.args.latest)
+			if len(gotToAdd) != len(tt.wantToAdd) || (len(gotToAdd) > 0 && !reflect.DeepEqual(gotToAdd, tt.wantToAdd)) {
+				t.Errorf("computeAccessPoliciesDelta() gotToAdd = %v, want %v", gotToAdd, tt.wantToAdd)
+			}
+			if len(gotToDelete) != len(tt.wantToDelete) || (len(gotToDelete) > 0 && !reflect.DeepEqual(gotToDelete, tt.wantToDelete)) {
+				b, _ := json.MarshalIndent(gotToDelete, "", "    ")
+				t.Log(string(b))
+				b, _ = json.MarshalIndent(tt.wantToDelete, "", "    ")
+				t.Log(string(b))
+				t.Errorf("computeAccessPoliciesDelta() gotToDelete = %v, want %v", gotToDelete, tt.wantToDelete)
+			}
+		})
+	}
+}

--- a/test/e2e/tests/test_cluster.py
+++ b/test/e2e/tests/test_cluster.py
@@ -264,6 +264,9 @@ class TestCluster:
         # Wait for the updating to become active again
         wait_for_cluster_active(eks_client, cluster_name)
 
+        # So we need to wait again for the CR to be updated.
+        time.sleep(CHECK_STATUS_WAIT_SECONDS*1.5)
+        
         # the cluster should be active again at version 1.29
         aws_res = eks_client.describe_cluster(name=cluster_name)
         assert aws_res["cluster"]["version"] == "1.29"


### PR DESCRIPTION
Prior to this patch, we observed some issues with the controller
behaviour regarding access policy association and delta computations,
specifically:
- False positive deltas were detected at every reconciliation (or
  controller restart)
- When a delta was detected, the controller disociate the latest
  policies, and patch the desired ones. (Even when it's unnecessary).

The root cause was identifier as the usage of `reflect.DeepEqual` for
slices. According to the `reflect` library [documentation](https://pkg.go.dev/reflect#DeepEqual)
`DeepEqual`  returns false if the comapred elements are a nil slice and
a "non-nil empty slice" (e.g `nil` and `[]string{}`).
This combined with the possibility of a user providing a nil
`namespaces` slice, while the controller sets an empty one (based on the
API response), cause behaviour inconsistencies.

Users shouldn't care/worry about the "nil-ity" of their arrays/slices;
it is up to the controller to accurately compute the deltas.

This patch replaces the usage of `reflect.DeepEqual` with a meticulous
custom delta function.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
