### PR TITLE
Ignore tag comparison for Identity provider config

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-05-28T22:22:45Z"
+  build_date: "2024-06-06T04:13:17Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
   go_version: go1.21.1
   version: v0.34.0
@@ -7,7 +7,7 @@ api_directory_checksum: 626700f8799840e0470b1ff7ef3dbb32665b9f9d
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.13
 generator_config_info:
-  file_checksum: 3e2332beafd7d7b5898a51082c0e96d9594775bb
+  file_checksum: c6dada6a685b8ed90112dab66773cc94314dd2b8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -101,6 +101,8 @@ resources:
           path: IdentityProviderConfig.Oidc.Status
       Tags:
         is_immutable: true
+        compare:
+          is_ignored: true
     hooks:
       sdk_delete_post_build_request:
         template_path: hooks/identity_provider_config/sdk_delete_post_build_request.go.tpl

--- a/generator.yaml
+++ b/generator.yaml
@@ -101,6 +101,8 @@ resources:
           path: IdentityProviderConfig.Oidc.Status
       Tags:
         is_immutable: true
+        compare:
+          is_ignored: true
     hooks:
       sdk_delete_post_build_request:
         template_path: hooks/identity_provider_config/sdk_delete_post_build_request.go.tpl

--- a/pkg/resource/identity_provider_config/delta.go
+++ b/pkg/resource/identity_provider_config/delta.go
@@ -113,9 +113,6 @@ func newResourceDelta(
 			}
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 
 	return delta
 }


### PR DESCRIPTION
tag update is not supported by identity provider config resource api. EKS controller tries to update the default tags like `services.k8s.aws/controller-version` whenever controller version changes. This results in controller errors. Since tag update is not supported by the apis, this fix ignores the tag comparison and thereby would never try to update tags.