### PR TITLE
Ensure Ref is not overwritten in Spec

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2024-08-29T17:14:13Z"
+  build_date: "2024-09-19T16:42:31Z"
   build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
-  go_version: go1.22.5
+  go_version: go1.23.0
   version: v0.38.1
 api_directory_checksum: 626700f8799840e0470b1ff7ef3dbb32665b9f9d
 api_version: v1alpha1

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -367,6 +367,14 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if r.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SubnetRefs = r.ko.Spec.ResourcesVPCConfig.SubnetRefs
+	}
+
+	if r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SecurityGroupRefs = r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs
+	}
+
 	if !clusterActive(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
@@ -374,7 +382,6 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
-
 	return &resource{ko}, nil
 }
 
@@ -707,6 +714,14 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if desired.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SubnetRefs = desired.ko.Spec.ResourcesVPCConfig.SubnetRefs
+	}
+
+	if desired.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SecurityGroupRefs = desired.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs
+	}
+
 	// We expect the cluster to be in 'CREATING' status since we just issued
 	// the call to create it, but I suppose it doesn't hurt to check here.
 	if clusterCreating(&resource{ko}) {

--- a/templates/hooks/cluster/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,11 @@
+	if desired.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SubnetRefs = desired.ko.Spec.ResourcesVPCConfig.SubnetRefs
+	}
+
+	if desired.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SecurityGroupRefs = desired.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs
+	}
+	
 	// We expect the cluster to be in 'CREATING' status since we just issued
 	// the call to create it, but I suppose it doesn't hurt to check here.
 	if clusterCreating(&resource{ko}) {
@@ -6,3 +14,4 @@
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 		return &resource{ko}, nil
 	}
+

--- a/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
@@ -1,3 +1,11 @@
+	if r.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SubnetRefs = r.ko.Spec.ResourcesVPCConfig.SubnetRefs
+	}
+
+	if r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
+		ko.Spec.ResourcesVPCConfig.SecurityGroupRefs = r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs
+	}
+	
 	if !clusterActive(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
@@ -5,4 +13,3 @@
 	} else {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
-


### PR DESCRIPTION
Issue [#1898](https://github.com/aws-controllers-k8s/community/issues/1898)

Description of changes:
Similarly as the ec2-controller, the ref stored in a 
struct is being overwritten during create/update. 
With this fix we ensure the ref would not be discarded.

Currently there isn't a way to test this fix, as we can't 
run two controllers simultaneously and reference subnet 
names in cluster directly.
Instead I will document an example with the fix working in this PR

provided:
```yaml
apiVersion: eks.services.k8s.aws/v1alpha1
kind: Cluster
metadata:
  name: my-clust
spec:
  name: my-clust
  roleARN: <removed>
  version: "1.30"
  resourcesVPCConfig:
    endpointPrivateAccess: true
    endpointPublicAccess: false
    subnetRefs:
      - from:
          name: sub1
      - from:
          name: sub2
```

Creating .spec and status:
```yaml
spec:
  accessConfig:
    authenticationMode: CONFIG_MAP
    bootstrapClusterCreatorAdminPermissions: true
  kubernetesNetworkConfig:
    ipFamily: ipv4
    serviceIPv4CIDR: 172.20.0.0/16
  logging:
    clusterLogging:
    - enabled: false
      types:
      - api
      - audit
      - authenticator
      - controllerManager
      - scheduler
  name: my-clust
  resourcesVPCConfig:
    endpointPrivateAccess: true
    endpointPublicAccess: true
    publicAccessCIDRs:
    - 0.0.0.0/0
    subnetRefs:
    - from:
        name: sub1
    - from:
        name: sub2
  roleARN: <removed>
  version: "1.30"
status:
  ackResourceMetadata:
    arn: <removed>
    ownerAccountID: <removed>
    region: us-west-2
  certificateAuthority: {}
  conditions:
  - lastTransitionTime: "2024-09-18T20:56:50Z"
    status: "True"
    type: ACK.ReferencesResolved
  - lastTransitionTime: "2024-09-18T20:56:51Z"
    status: "False"
    type: ACK.ResourceSynced
  createdAt: "2024-09-18T20:56:50Z"
  health: {}
  platformVersion: eks.8
  status: CREATING
```

Active:
```yaml
spec:
  accessConfig:
    authenticationMode: CONFIG_MAP
    bootstrapClusterCreatorAdminPermissions: true
  kubernetesNetworkConfig:
    ipFamily: ipv4
    serviceIPv4CIDR: 172.20.0.0/16
  logging:
    clusterLogging:
    - enabled: false
      types:
      - api
      - audit
      - authenticator
      - controllerManager
      - scheduler
  name: my-clust
  resourcesVPCConfig:
    endpointPrivateAccess: true
    endpointPublicAccess: true
    publicAccessCIDRs:
    - 0.0.0.0/0
    subnetRefs:
    - from:
        name: sub1
    - from:
        name: sub2
  roleARN: <removed>
  version: "1.30"
status:
  ackResourceMetadata:
    <removed>
    ownerAccountID: <removed>
    region: us-west-2
  certificateAuthority:
    data: <removed>
  conditions:
  - lastTransitionTime: "2024-09-18T22:00:27Z"
    status: "True"
    type: ACK.ReferencesResolved
  - lastTransitionTime: "2024-09-18T22:00:28Z"
    status: "True"
    type: ACK.ResourceSynced
  createdAt: "2024-09-18T20:56:50Z"
  endpoint: https://DFD284F7337766E87670192E4EB46565.gr7.us-west-2.eks.amazonaws.com
  health: {}
  identity:
    oidc:
      issuer: https://oidc.eks.us-west-2.amazonaws.com/id/DFD284F7337766E87670192E4EB46565
  platformVersion: eks.8
  status: ACTIVE
```
Updating:
```yaml
spec:
  accessConfig:
    authenticationMode: CONFIG_MAP
    bootstrapClusterCreatorAdminPermissions: true
  kubernetesNetworkConfig:
    ipFamily: ipv4
    serviceIPv4CIDR: 172.20.0.0/16
  logging:
    clusterLogging:
    - enabled: false
      types:
      - api
      - audit
      - authenticator
      - controllerManager
      - scheduler
  name: my-clust
  resourcesVPCConfig:
    endpointPrivateAccess: true
    endpointPublicAccess: false
    publicAccessCIDRs:
    - 0.0.0.0/0
    subnetRefs:
    - from:
        name: sub1
    - from:
        name: sub2
  roleARN: <removed>
  version: "1.30"
status:
  ackResourceMetadata:
    arn: <removed>
    ownerAccountID: <removed>
    region: us-west-2
  certificateAuthority:
    data: <removed>
  conditions:
  - lastTransitionTime: "2024-09-18T22:04:38Z"
    status: "True"
    type: ACK.ReferencesResolved
  - lastTransitionTime: "2024-09-18T22:04:38Z"
    message: Cluster is in 'UPDATING' status
    status: "False"
    type: ACK.ResourceSynced
  - message: cluster in 'UPDATING' state, cannot be modified until 'ACTIVE'
    status: "True"
    type: ACK.Recoverable
  createdAt: "2024-09-18T20:56:50Z"
  endpoint: https://DFD284F7337766E87670192E4EB46565.gr7.us-west-2.eks.amazonaws.com
  health: {}
  identity:
    oidc:
      issuer: https://oidc.eks.us-west-2.amazonaws.com/id/DFD284F7337766E87670192E4EB46565
  platformVersion: eks.8
  status: UPDATING
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
