### PR TITLE
mitigate runtime panic when adopting cluster

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-09-19T16:42:31Z"
+  build_date: "2024-09-30T17:24:49Z"
   build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
   go_version: go1.23.0
   version: v0.38.1

--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -192,10 +192,12 @@ func (rm *resourceManager) customUpdate(
 		return updatedRes, requeueWaitUntilCanModify(latest)
 	}
 
+	// Ensure ACKResourceMetadata and ARN are not nil before derefrencing
+	// This can occur when adopting a resource
 	if delta.DifferentAt("Spec.Tags") {
 		if err := tags.SyncTags(
 			ctx, rm.sdkapi, rm.metrics,
-			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			string(*latest.ko.Status.ACKResourceMetadata.ARN),
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		); err != nil {
 			return nil, err

--- a/pkg/resource/cluster/sdk.go
+++ b/pkg/resource/cluster/sdk.go
@@ -367,11 +367,11 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	if r.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
+	if r.ko.Spec.ResourcesVPCConfig != nil && r.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
 		ko.Spec.ResourcesVPCConfig.SubnetRefs = r.ko.Spec.ResourcesVPCConfig.SubnetRefs
 	}
 
-	if r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
+	if r.ko.Spec.ResourcesVPCConfig != nil && r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
 		ko.Spec.ResourcesVPCConfig.SecurityGroupRefs = r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs
 	}
 

--- a/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/cluster/sdk_read_one_post_set_output.go.tpl
@@ -1,8 +1,8 @@
-	if r.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
+	if r.ko.Spec.ResourcesVPCConfig != nil && r.ko.Spec.ResourcesVPCConfig.SubnetRefs != nil {
 		ko.Spec.ResourcesVPCConfig.SubnetRefs = r.ko.Spec.ResourcesVPCConfig.SubnetRefs
 	}
 
-	if r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
+	if r.ko.Spec.ResourcesVPCConfig != nil && r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs != nil {
 		ko.Spec.ResourcesVPCConfig.SecurityGroupRefs = r.ko.Spec.ResourcesVPCConfig.SecurityGroupRefs
 	}
 	


### PR DESCRIPTION
Description of Changes:
This change makes null checks to avoid panics.
Panic was noticed when trying to adopt a resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
