### PR TITLE
mitigate controller panic when adopting resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-09-30T17:24:49Z"
+  build_date: "2024-10-01T19:56:53Z"
   build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
   go_version: go1.23.0
   version: v0.38.1

--- a/pkg/resource/access_entry/sdk.go
+++ b/pkg/resource/access_entry/sdk.go
@@ -340,7 +340,7 @@ func (rm *resourceManager) sdkUpdate(
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(
 			ctx, rm.sdkapi, rm.metrics,
-			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			string(*latest.ko.Status.ACKResourceMetadata.ARN),
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		)
 		if err != nil {

--- a/pkg/resource/fargate_profile/hook.go
+++ b/pkg/resource/fargate_profile/hook.go
@@ -76,7 +76,7 @@ func (rm *resourceManager) customUpdate(
 	if delta.DifferentAt("Spec.Tags") {
 		if err := tags.SyncTags(
 			ctx, rm.sdkapi, rm.metrics,
-			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			string(*latest.ko.Status.ACKResourceMetadata.ARN),
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		); err != nil {
 			return nil, err

--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -265,7 +265,7 @@ func (rm *resourceManager) customUpdate(
 	if delta.DifferentAt("Spec.Tags") {
 		err := tags.SyncTags(
 			ctx, rm.sdkapi, rm.metrics,
-			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			string(*latest.ko.Status.ACKResourceMetadata.ARN),
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		)
 		if err != nil {

--- a/templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl
@@ -7,7 +7,7 @@
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(
 			ctx, rm.sdkapi, rm.metrics, 
-			string(*desired.ko.Status.ACKResourceMetadata.ARN), 
+			string(*latest.ko.Status.ACKResourceMetadata.ARN), 
 			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 		)
 		if err != nil {


### PR DESCRIPTION
Description of changes:
When adopting resources, the desired status arn is nil, 
and it causes the controller to panic and exit
To ensure this doesn't happen, we are retrieving
the resource ARN from AWS API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
