### PR TITLE
Include additional keys to adopt `identityProviderConfig`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-10-10T03:55:41Z"
-  build_hash: 36c2d234498c2bc4f60773ab8df632af4067f43b
+  build_date: "2024-10-17T18:27:35Z"
+  build_hash: ab15f9206796e9660c51695fab0ff07a09ea28e2
   go_version: go1.23.2
-  version: v0.39.1
-api_directory_checksum: d736919240d3843865e860f7cb685cec30921bd4
+  version: v0.39.1-2-gab15f92
+api_directory_checksum: 4cfe0b6ec81b65719c1f165983b84116135f5e40
 api_version: v1alpha1
 aws_sdk_go_version: v1.55.5
 generator_config_info:
-  file_checksum: 157f31e5a8ce8e0e922e4e5c2e406841ec1a8136
+  file_checksum: 5b5c72cb103e99a0dd19beffb8863f16e4fd163e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -145,6 +145,8 @@ resources:
         template_path: hooks/identity_provider_config/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/identity_provider_config/sdk_read_one_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/identity_provider_config/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdate
   Cluster:

--- a/generator.yaml
+++ b/generator.yaml
@@ -145,6 +145,8 @@ resources:
         template_path: hooks/identity_provider_config/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/identity_provider_config/sdk_read_one_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/identity_provider_config/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdate
   Cluster:

--- a/pkg/resource/identity_provider_config/resource.go
+++ b/pkg/resource/identity_provider_config/resource.go
@@ -90,6 +90,18 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Spec.ClusterName = &identifier.NameOrID
 
+	if identifier.AdditionalKeys == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	f0, f0ok := identifier.AdditionalKeys["identityProviderConfigName"]
+	if f0ok {
+		r.ko.Spec.OIDC = &svcapitypes.OIDCIdentityProviderConfigRequest{
+			IdentityProviderConfigName: &f0,
+		}
+	} else {
+		return ackerrors.MissingNameIdentifier
+	}
+
 	return nil
 }
 

--- a/templates/hooks/identity_provider_config/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/identity_provider_config/post_set_resource_identifiers.go.tpl
@@ -1,0 +1,12 @@
+
+	if identifier.AdditionalKeys == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	f0, f0ok := identifier.AdditionalKeys["identityProviderConfigName"]
+	if f0ok {
+		r.ko.Spec.OIDC = &svcapitypes.OIDCIdentityProviderConfigRequest{
+			IdentityProviderConfigName: &f0,
+		}
+	} else {
+		return ackerrors.MissingNameIdentifier
+	}


### PR DESCRIPTION
Issue [#2193](https://github.com/aws-controllers-k8s/community/issues/2193)

Description of changes:
This change ensures users are required 
to provide an `identityProviderConfigName`
when adopting the resource, as it is a required
 input field.

Not sure if we should change that to the primary 
`NameOrID`, and make `clusterName` an additional Key..


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
