### PR TITLE
Set default cluster `UpgradePolicy` is not provided

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-10-17T18:27:35Z"
+  build_date: "2024-10-21T22:52:48Z"
   build_hash: ab15f9206796e9660c51695fab0ff07a09ea28e2
   go_version: go1.23.2
   version: v0.39.1-2-gab15f92
@@ -7,7 +7,7 @@ api_directory_checksum: 4cfe0b6ec81b65719c1f165983b84116135f5e40
 api_version: v1alpha1
 aws_sdk_go_version: v1.55.5
 generator_config_info:
-  file_checksum: 5b5c72cb103e99a0dd19beffb8863f16e4fd163e
+  file_checksum: 6c1343508adb97d2a4ff6f8328b2668356317b3b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -195,6 +195,8 @@ resources:
         - MissingParameter
         - ValidationError
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(a, b)
       sdk_create_post_set_output:
         template_path: hooks/cluster/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -195,6 +195,8 @@ resources:
         - MissingParameter
         - ValidationError
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(a, b)
       sdk_create_post_set_output:
         template_path: hooks/cluster/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:

--- a/pkg/resource/cluster/delta.go
+++ b/pkg/resource/cluster/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AccessConfig, b.ko.Spec.AccessConfig) {
 		delta.Add("Spec.AccessConfig", a.ko.Spec.AccessConfig, b.ko.Spec.AccessConfig)

--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -160,6 +160,15 @@ func (rm *resourceManager) clusterInUse(ctx context.Context, r *resource) (bool,
 	return (nodes != nil && len(nodes.Nodegroups) > 0), nil
 }
 
+func customPreCompare(
+	a *resource,
+	b *resource,
+) {
+	if a.ko.Spec.UpgradePolicy == nil && b.ko.Spec.UpgradePolicy != nil {
+		a.ko.Spec.UpgradePolicy = b.ko.Spec.UpgradePolicy.DeepCopy()
+	}
+}
+
 func (rm *resourceManager) customUpdate(
 	ctx context.Context,
 	desired *resource,


### PR DESCRIPTION
Description of changes:
Currently, when a cluster has been created with an 
older eks controller, and tries to reconcile with a new 
one, UpgradePolicy is set to nil, and panics with nulll 
pointer exception during updateClusterUpgradePolicy 
operation.

As a fix, I am considering setting the upgradePolicy to 
the value that is retured from AWS to ensure user's 
preset option is maintained.

This change will not change the customer's spec,
until the users deside to define/add the field
themselves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
