### PR TITLE
remove getImmutableFieldChanges references

### DIFF
--- a/pkg/resource/identity_provider_config/hooks.go
+++ b/pkg/resource/identity_provider_config/hooks.go
@@ -15,11 +15,8 @@ package identity_provider_config
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 )
 
@@ -83,11 +80,6 @@ func (rm *resourceManager) customUpdate(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.customUpdate")
 	defer exit(err)
-
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 
 	return nil, nil
 }

--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -257,11 +256,6 @@ func (rm *resourceManager) customUpdate(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.customUpdate")
 	defer exit(err)
-
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 
 	if delta.DifferentAt("Spec.Tags") {
 		err := tags.SyncTags(


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove getImmutableFieldChanges from hooks to support cel immutability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
