### PR TITLE
feat: add DesiredSize to NodegroupStatus

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-04-04T04:43:23Z"
-  build_hash: f5a9ac2db3296fac3aa18dacf282267b15229ad1
-  go_version: go1.24.1
-  version: v0.44.0-2-gf5a9ac2
-api_directory_checksum: 99ed3c67c10b10fb277bcbe40a10712ec9dd8595
+  build_date: "2025-04-10T23:52:19Z"
+  build_hash: 0909e7f0adb8ffe4120a8c20d5d58b991f2539e9
+  go_version: go1.24.0
+  version: v0.44.0-3-g0909e7f
+api_directory_checksum: e1284610b12e8a87dde6ba9c99a9025f5b76f6d2
 api_version: v1alpha1
 aws_sdk_go_version: v1.36.3
 generator_config_info:
-  file_checksum: 4615b96497cd57742b072f9ab8ae025ac2da2ca0
+  file_checksum: 0dd14fb110a3f5752e37da4d8bf5247180ed2057
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -308,6 +308,12 @@ resources:
         priority: 1
   Nodegroup:
     fields:
+      DesiredSize:
+        is_read_only: true
+        type: int
+        # ideally, this should work. We do not need to create a new file
+        # dedicated to documentation.
+        documentation: "DesiredSize is the observed desired size of the node group in AWS."
       ClusterName:
         references:
           resource: Cluster
@@ -408,7 +414,7 @@ resources:
         index: 40
         priority: 1
       - name: DESIREDSIZE
-        json_path: .spec.scalingConfig.desiredSize
+        json_path: .status.desiredSize
         type: integer
         index: 50
       - name: MINSIZE

--- a/apis/v1alpha1/nodegroup.go
+++ b/apis/v1alpha1/nodegroup.go
@@ -161,6 +161,8 @@ type NodegroupStatus struct {
 	// The Unix epoch timestamp at object creation.
 	// +kubebuilder:validation:Optional
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+	// +kubebuilder:validation:Optional
+	DesiredSize *int64 `json:"desiredSize,omitempty"`
 	// The health status of the node group. If there are issues with your node group's
 	// health, they are listed here.
 	// +kubebuilder:validation:Optional
@@ -184,7 +186,7 @@ type NodegroupStatus struct {
 // +kubebuilder:printcolumn:name="VERSION",type=string,priority=0,JSONPath=`.spec.version`
 // +kubebuilder:printcolumn:name="STATUS",type=string,priority=0,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="RELEASEVERSION",type=string,priority=1,JSONPath=`.spec.releaseVersion`
-// +kubebuilder:printcolumn:name="DESIREDSIZE",type=integer,priority=0,JSONPath=`.spec.scalingConfig.desiredSize`
+// +kubebuilder:printcolumn:name="DESIREDSIZE",type=integer,priority=0,JSONPath=`.status.desiredSize`
 // +kubebuilder:printcolumn:name="MINSIZE",type=integer,priority=0,JSONPath=`.spec.scalingConfig.minSize`
 // +kubebuilder:printcolumn:name="MAXSIZE",type=integer,priority=0,JSONPath=`.spec.scalingConfig.maxSize`
 // +kubebuilder:printcolumn:name="DISKSIZE",type=integer,priority=1,JSONPath=`.spec.diskSize`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -3332,6 +3332,11 @@ func (in *NodegroupStatus) DeepCopyInto(out *NodegroupStatus) {
 		in, out := &in.CreatedAt, &out.CreatedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.DesiredSize != nil {
+		in, out := &in.DesiredSize, &out.DesiredSize
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Health != nil {
 		in, out := &in.Health, &out.Health
 		*out = new(NodegroupHealth)

--- a/config/crd/bases/eks.services.k8s.aws_nodegroups.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_nodegroups.yaml
@@ -28,7 +28,7 @@ spec:
       name: RELEASEVERSION
       priority: 1
       type: string
-    - jsonPath: .spec.scalingConfig.desiredSize
+    - jsonPath: .status.desiredSize
       name: DESIREDSIZE
       type: integer
     - jsonPath: .spec.scalingConfig.minSize
@@ -429,6 +429,9 @@ spec:
                 description: The Unix epoch timestamp at object creation.
                 format: date-time
                 type: string
+              desiredSize:
+                format: int64
+                type: integer
               health:
                 description: |-
                   The health status of the node group. If there are issues with your node group's

--- a/generator.yaml
+++ b/generator.yaml
@@ -308,6 +308,12 @@ resources:
         priority: 1
   Nodegroup:
     fields:
+      DesiredSize:
+        is_read_only: true
+        type: int
+        # ideally, this should work. We do not need to create a new file
+        # dedicated to documentation.
+        documentation: "DesiredSize is the observed desired size of the node group in AWS."
       ClusterName:
         references:
           resource: Cluster
@@ -408,7 +414,7 @@ resources:
         index: 40
         priority: 1
       - name: DESIREDSIZE
-        json_path: .spec.scalingConfig.desiredSize
+        json_path: .status.desiredSize
         type: integer
         index: 50
       - name: MINSIZE

--- a/helm/crds/eks.services.k8s.aws_nodegroups.yaml
+++ b/helm/crds/eks.services.k8s.aws_nodegroups.yaml
@@ -28,7 +28,7 @@ spec:
       name: RELEASEVERSION
       priority: 1
       type: string
-    - jsonPath: .spec.scalingConfig.desiredSize
+    - jsonPath: .status.desiredSize
       name: DESIREDSIZE
       type: integer
     - jsonPath: .spec.scalingConfig.minSize
@@ -429,6 +429,9 @@ spec:
                 description: The Unix epoch timestamp at object creation.
                 format: date-time
                 type: string
+              desiredSize:
+                format: int64
+                type: integer
               health:
                 description: |-
                   The health status of the node group. If there are issues with your node group's

--- a/pkg/resource/nodegroup/sdk.go
+++ b/pkg/resource/nodegroup/sdk.go
@@ -297,6 +297,10 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if ko.Spec.ScalingConfig != nil && ko.Spec.ScalingConfig.DesiredSize != nil {
+		ko.Status.DesiredSize = ko.Spec.ScalingConfig.DesiredSize
+	}
+
 	if !nodegroupActive(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.

--- a/templates/hooks/nodegroup/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/nodegroup/sdk_read_one_post_set_output.go.tpl
@@ -1,3 +1,7 @@
+	if ko.Spec.ScalingConfig != nil && ko.Spec.ScalingConfig.DesiredSize != nil {
+		ko.Status.DesiredSize = ko.Spec.ScalingConfig.DesiredSize
+	}
+
 	if !nodegroupActive(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.


### PR DESCRIPTION
This commit adds the DesiredSize field to the NodegroupStatus struct, allowing
users to observe the desired size of node groups in AWS directly from the status.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
