### PR TITLE
chore: Set cluster status to updating after successful update

### DIFF
--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -168,6 +168,7 @@ func clusterDeleting(r *resource) bool {
 func returnClusterUpdating(r *resource) (*resource, error) {
 	msg := "Cluster is currently being updated"
 	ackcondition.SetSynced(r, corev1.ConditionFalse, &msg, nil)
+	r.ko.Status.Status = aws.String(string(svcsdktypes.ClusterStatusUpdating))
 	return r, requeueAfterAsyncUpdate()
 }
 
@@ -451,7 +452,7 @@ func (rm *resourceManager) updateVersion(
 		)
 	}
 
-	// Compure the next minor version of the desired version
+	// Compute the next minor version of the desired version
 	nextVersion, err := util.IncrementEKSMinorVersion(*latest.ko.Spec.Version)
 	if err != nil {
 		return ackerr.NewTerminalError(fmt.Errorf("failed to compute the next minor version: %v", err))


### PR DESCRIPTION
Description of changes:
Currently, when we successfully update an EKS cluster, trigger a
controller 15 second requeue.
During these 15 seconds, the actual cluster Status does not get updated,
meaning, if previously it was Active, it will remain Active until the
end of the 15 seconds where the controller will change it to Updating.

With this change, we will be setting the Updating status ourselves when
the update api call is successful, and during the next reconciliation
(still 15 seconds) the controller will change it to whatever status is
returned by the AWS API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
