### PR TITLE
fix: set proper desiredSize when increasing minSize

### DIFF
--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -548,6 +548,9 @@ func (rm *resourceManager) newUpdateScalingConfigPayload(
 		)
 		temp := int32(*latest.ko.Spec.ScalingConfig.DesiredSize)
 		sc.DesiredSize = &temp
+		if *sc.MinSize > *sc.DesiredSize {
+			*sc.DesiredSize = *sc.MinSize
+		}
 	}
 	return sc, nil
 }

--- a/pkg/resource/nodegroup/hook_test.go
+++ b/pkg/resource/nodegroup/hook_test.go
@@ -346,7 +346,7 @@ func Test_resourceManager_newUpdateScalingConfigPayload_ManagedByExternalAutosca
 				desired: newNodegroupScalingConfigManagedByExternalAutoscaler(20, 15, 20),
 				latest:  newNodegroupScalingConfigManagedByExternalAutoscaler(10, 10, 10),
 			},
-			want:    newUpdateScalingConfigPayload(10, 15, 20),
+			want:    newUpdateScalingConfigPayload(20, 15, 20),
 			wantErr: false,
 		},
 		{
@@ -355,7 +355,7 @@ func Test_resourceManager_newUpdateScalingConfigPayload_ManagedByExternalAutosca
 				desired: newNodegroupScalingConfigManagedByExternalAutoscaler(10, 15, 20),
 				latest:  newNodegroupScalingConfigManagedByExternalAutoscaler(10, 10, 10),
 			},
-			want:    newUpdateScalingConfigPayload(10, 15, 20),
+			want:    newUpdateScalingConfigPayload(20, 15, 20),
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Description of changes:

When desiredSize is managed by external autoscaling, the ACK EKS controller will not increase minSize if it exceeds desiredSize, instead reporting the following error:

```
  Conditions:
    Last Transition Time:  2025-09-02T12:59:44Z
    Status:                True
    Type:                  ACK.ResourceSynced
    Message:               InvalidParameterException: Minimum capacity 2 can't be greater than desired size 1
    Status:                True
    Type:                  ACK.Terminal
```

This PR ensures that when minSize exceeds desiredSize, the desiredSize will be automatically adjusted to match minSize, preventing the operation from failing and ensuring successful resource updating.
