### PR TITLE
Fix panic updating tags during adoption

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-08-15T00:01:38Z"
-  build_hash: b6df33f8c7f55b234555c0b578b8de43c74771a8
-  go_version: go1.24.6
-  version: v0.51.0
+  build_date: "2025-09-12T18:54:57Z"
+  build_hash: 1d9076d0211773ff8ab8682b28b912c7ece10676
+  go_version: go1.25.0
+  version: v0.51.0-2-g1d9076d
 api_directory_checksum: 2b5e65a1d5f0a032d51209f925b714aff4b6dc96
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.0

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-12T18:54:57Z"
-  build_hash: 1d9076d0211773ff8ab8682b28b912c7ece10676
+  build_date: "2025-09-15T20:18:06Z"
+  build_hash: 9e29f017d9e942548af133d2f31aecae248a8816
   go_version: go1.25.0
-  version: v0.51.0-2-g1d9076d
+  version: v0.51.0-3-g9e29f01
 api_directory_checksum: 2b5e65a1d5f0a032d51209f925b714aff4b6dc96
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.0

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "ack-eks-controller.app.name" . }}
     helm.sh/chart: {{ include "ack-eks-controller.chart.name-version" . }}
+{{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:

--- a/pkg/resource/access_entry/resource.go
+++ b/pkg/resource/access_entry/resource.go
@@ -103,16 +103,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["clusterName"]
+	primaryKey, ok := fields["clusterName"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: clusterName"))
 	}
-	r.ko.Spec.ClusterName = &tmp
-
-	f1, f1ok := fields["principalARN"]
-	if f1ok {
-		r.ko.Spec.PrincipalARN = aws.String(f1)
+	r.ko.Spec.ClusterName = &primaryKey
+	f1, ok := fields["principalARN"]
+	if !ok {
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: principalARN"))
 	}
+	r.ko.Spec.PrincipalARN = &f1
 
 	return nil
 }

--- a/pkg/resource/addon/resource.go
+++ b/pkg/resource/addon/resource.go
@@ -103,16 +103,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	f0, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
-
-	f1, f1ok := fields["clusterName"]
-	if f1ok {
-		r.ko.Spec.ClusterName = aws.String(f1)
+	r.ko.Spec.Name = &f0
+	f1, ok := fields["clusterName"]
+	if !ok {
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: clusterName"))
 	}
+	r.ko.Spec.ClusterName = &f1
 
 	return nil
 }

--- a/pkg/resource/addon/sdk.go
+++ b/pkg/resource/addon/sdk.go
@@ -449,7 +449,7 @@ func (rm *resourceManager) sdkUpdate(
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(
 			ctx, rm.sdkapi, rm.metrics,
-			string(*desired.ko.Status.ACKResourceMetadata.ARN),
+			string(*latest.ko.Status.ACKResourceMetadata.ARN),
 			aws.ToStringMap(desired.ko.Spec.Tags), aws.ToStringMap(latest.ko.Spec.Tags),
 		)
 		if err != nil {

--- a/pkg/resource/cluster/resource.go
+++ b/pkg/resource/cluster/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	f0, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
+	r.ko.Spec.Name = &f0
 
 	return nil
 }

--- a/pkg/resource/fargate_profile/resource.go
+++ b/pkg/resource/fargate_profile/resource.go
@@ -103,16 +103,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	f0, ok := fields["clusterName"]
+	if !ok {
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: clusterName"))
+	}
+	r.ko.Spec.ClusterName = &f0
+	f1, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
-
-	f0, f0ok := fields["clusterName"]
-	if f0ok {
-		r.ko.Spec.ClusterName = aws.String(f0)
-	}
+	r.ko.Spec.Name = &f1
 
 	return nil
 }

--- a/pkg/resource/identity_provider_config/resource.go
+++ b/pkg/resource/identity_provider_config/resource.go
@@ -109,11 +109,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["clusterName"]
+	primaryKey, ok := fields["clusterName"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: clusterName"))
 	}
-	r.ko.Spec.ClusterName = &tmp
+	r.ko.Spec.ClusterName = &primaryKey
 
 	if f0, f0ok := fields["identityProviderConfigName"]; f0ok {
 		r.ko.Spec.OIDC = &svcapitypes.OIDCIdentityProviderConfigRequest{

--- a/pkg/resource/nodegroup/resource.go
+++ b/pkg/resource/nodegroup/resource.go
@@ -103,16 +103,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	f0, ok := fields["clusterName"]
+	if !ok {
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: clusterName"))
+	}
+	r.ko.Spec.ClusterName = &f0
+	f1, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
-
-	f0, f0ok := fields["clusterName"]
-	if f0ok {
-		r.ko.Spec.ClusterName = aws.String(f0)
-	}
+	r.ko.Spec.Name = &f1
 
 	return nil
 }

--- a/pkg/resource/pod_identity_association/resource.go
+++ b/pkg/resource/pod_identity_association/resource.go
@@ -103,16 +103,16 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["clusterName"]
+	primaryKey, ok := fields["clusterName"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: clusterName"))
 	}
-	r.ko.Spec.ClusterName = &tmp
-
-	f0, f0ok := fields["associationID"]
-	if f0ok {
-		r.ko.Status.AssociationID = aws.String(f0)
+	r.ko.Spec.ClusterName = &primaryKey
+	f0, ok := fields["associationID"]
+	if !ok {
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: associationID"))
 	}
+	r.ko.Status.AssociationID = &f0
 
 	return nil
 }

--- a/templates/hooks/addons/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/addons/sdk_update_pre_build_request.go.tpl
@@ -16,7 +16,7 @@
 	if delta.DifferentAt("Spec.Tags") {
 		err := syncTags(
 			ctx, rm.sdkapi, rm.metrics, 
-			string(*desired.ko.Status.ACKResourceMetadata.ARN), 
+			string(*latest.ko.Status.ACKResourceMetadata.ARN), 
 			aws.ToStringMap(desired.ko.Spec.Tags), aws.ToStringMap(latest.ko.Spec.Tags),
 		)
 		if err != nil {


### PR DESCRIPTION
Issue #, if available: [2621](https://github.com/aws-controllers-k8s/community/issues/2621)

Description of changes:
- Retrieve resource ARN from latest instead of desired to avoid panic. Desired ARN is not populated on first update when adopting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
