### PR TITLE
Ignore Node Version and EKS Version check if AMI Type is bottlerocket

### DIFF
--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -330,7 +330,7 @@ func (rm *resourceManager) customUpdate(
 		if desired.ko.Spec.Version != nil && desired.ko.Spec.ReleaseVersion != nil &&
 			*desired.ko.Spec.Version != "" && *desired.ko.Spec.ReleaseVersion != "" {
 
-			if !isAMITypeBottleRocket(desired.ko.Spec.AMIType) {
+			if !isAMITypeBottlerocket(desired.ko.Spec.AMIType) {
 				// First parse the user provided release version and desired release
 				desiredReleaseVersionTrimmed, err := util.GetEKSVersionFromReleaseVersion(*desired.ko.Spec.ReleaseVersion)
 				if err != nil {
@@ -361,10 +361,10 @@ func (rm *resourceManager) customUpdate(
 	return updatedRes, nil
 }
 
-// BottleRocket AMI types do not follow the same versioning scheme as other AMI types.
+// Bottlerocket AMI types do not follow the same versioning scheme as other AMI types.
 // For more information, see https://github.com/awslabs/amazon-eks-ami/releases
 // and https://github.com/bottlerocket-os/bottlerocket/releases
-func isAMITypeBottleRocket(amiType *string) bool {
+func isAMITypeBottlerocket(amiType *string) bool {
 	if amiType == nil {
 		return false
 	}

--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -369,14 +370,11 @@ func isAMITypeBottlerocket(amiType *string) bool {
 		return false
 	}
 
-	switch *amiType {
-	case string(svcapitypes.AMITypes_BOTTLEROCKET_ARM_64), string(svcapitypes.AMITypes_BOTTLEROCKET_ARM_64_FIPS),
-		string(svcapitypes.AMITypes_BOTTLEROCKET_ARM_64_NVIDIA), string(svcapitypes.AMITypes_BOTTLEROCKET_x86_64),
-		string(svcapitypes.AMITypes_BOTTLEROCKET_x86_64_FIPS), string(svcapitypes.AMITypes_BOTTLEROCKET_x86_64_NVIDIA):
+	if strings.HasPrefix(*amiType, "BOTTLEROCKET_") {
 		return true
-	default:
-		return false
 	}
+
+	return false
 }
 
 // newUpdateLabelsPayload determines which of the labels should be added or

--- a/pkg/resource/nodegroup/hook_test.go
+++ b/pkg/resource/nodegroup/hook_test.go
@@ -550,3 +550,53 @@ func Test_newUpdateNodegroupPayload(t *testing.T) {
 		})
 	}
 }
+
+func Test_AMITypeBottlerocket(t *testing.T) {
+	tests := []struct {
+		name    string
+		amiType *string
+		want    bool
+	}{
+		{
+			name:    "nil ami type",
+			amiType: nil,
+			want:    false,
+		},
+		{
+			name:    "BOTTLEROCKET_ARM_64 AMI",
+			amiType: aws.String("BOTTLEROCKET_ARM_64"),
+			want:    true,
+		},
+		{
+			name:    "BOTTLEROCKET_ARM_64_NVIDIA AMI",
+			amiType: aws.String("BOTTLEROCKET_ARM_64_NVIDIA"),
+			want:    true,
+		},
+		{
+			name:    "BOTTLEROCKET_x86_64 AMI",
+			amiType: aws.String("BOTTLEROCKET_x86_64"),
+			want:    true,
+		},
+		{
+			name:    "BOTTLEROCKET_x86_64_FIPS AMI",
+			amiType: aws.String("BOTTLEROCKET_x86_64_FIPS"),
+			want:    true,
+		},
+		{
+			name:    "BOTTLEROCKET_x86_64_NVIDIA AMI",
+			amiType: aws.String("BOTTLEROCKET_x86_64_NVIDIA"),
+			want:    true,
+		},
+		{
+			name:    "RANDOM AMI",
+			amiType: aws.String("RANDOM"),
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAMITypeBottlerocket(tt.amiType))
+		})
+	}
+}


### PR DESCRIPTION
Issue #, if available:
- https://github.com/aws-controllers-k8s/community/issues/2644

Description of changes:
Since the bottlerocket versions don't align with EKS Versions, we should ignore the check of comparing nodeversion and eks version. Otherwise, it will result in error similar to `version and release version do not match: 1.32 and 1.47`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
