### PR TITLE
Use only one of ID or Name while updating Nodegroup

### DIFF
--- a/pkg/resource/nodegroup/hook.go
+++ b/pkg/resource/nodegroup/hook.go
@@ -492,7 +492,7 @@ func newUpdateNodegroupVersionPayload(
 				input.LaunchTemplate.Name = desired.ko.Spec.LaunchTemplate.Name
 			}
 
-			input.Version = desired.ko.Spec.LaunchTemplate.Version
+			input.LaunchTemplate.Version = desired.ko.Spec.LaunchTemplate.Version
 		}
 	}
 


### PR DESCRIPTION
Issue #, if available:
- https://github.com/aws-controllers-k8s/community/issues/2645

Description of changes:
Use only one of ID or Name while updating Nodegroup. ID is the priority here. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. Yes