### PR TITLE
chore: allow PIA adoption by clusterName, namespace, and ServiceAccount

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-24T18:39:09Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.0
-  version: v0.60.0
-api_directory_checksum: d70db4d0393696a439c4dac24b5b265d8b28d3d0
+  build_date: "2026-06-26T19:32:54Z"
+  build_hash: 016cc97b328515c8db205ad1091916a0cc66614b
+  go_version: go1.26.4
+  version: v0.60.0-2-g016cc97
+api_directory_checksum: 223ceb0e1212b81c2171ee1932a74a3b418540b4
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: d5776037b4bf1291dc7c62e4fbda96f47eef5c4b
+  file_checksum: 20146e33a2063c52a6f7c94d595c562fa608fc28
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -457,6 +457,8 @@ resources:
         template_path: hooks/pod_identity_association/sdk_update_post_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/pod_identity_association/sdk_read_one_post_set_output.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/pod_identity_association/sdk_read_one_pre_build_request.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/pod_identity_association/sdk_create_post_set_output.go.tpl
     fields:

--- a/generator.yaml
+++ b/generator.yaml
@@ -457,6 +457,8 @@ resources:
         template_path: hooks/pod_identity_association/sdk_update_post_build_request.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/pod_identity_association/sdk_read_one_post_set_output.go.tpl
+      sdk_read_one_pre_build_request:
+        template_path: hooks/pod_identity_association/sdk_read_one_pre_build_request.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/pod_identity_association/sdk_create_post_set_output.go.tpl
     fields:

--- a/pkg/resource/pod_identity_association/hooks.go
+++ b/pkg/resource/pod_identity_association/hooks.go
@@ -14,7 +14,63 @@
 package pod_identity_association
 
 import (
+	"context"
+
 	"github.com/aws-controllers-k8s/eks-controller/pkg/tags"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/eks"
 )
 
 var syncTags = tags.SyncTags
+
+func (rm *resourceManager) getAssociationID(ctx context.Context, r *resource) (id *string, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.getSecretID")
+	defer func() {
+		exit(err)
+	}()
+
+	// ClusterName is a required field for ListPodIdentityAssociations operation
+	// we treat an undefined ClusterName as not found.
+	if r.ko.Spec.ClusterName == nil {
+		return nil, nil
+	}
+
+	resp, err := rm.sdkapi.ListPodIdentityAssociations(ctx, &svcsdk.ListPodIdentityAssociationsInput{
+		ClusterName:    r.ko.Spec.ClusterName,
+		Namespace:      r.ko.Spec.Namespace,
+		ServiceAccount: r.ko.Spec.ServiceAccount,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// if more than one are returned, we don't want to manage them
+	// and treat it as not found
+	if len(resp.Associations) != 1 {
+		return nil, nil
+	}
+
+	// expect Namespace, ClusterName, and ServiceAccount defined by the user
+	// to match the returned association
+	pia := resp.Associations[0]
+	if !isPtrEqual(pia.ClusterName, r.ko.Spec.ClusterName) ||
+		!isPtrEqual(pia.Namespace, r.ko.Spec.Namespace) ||
+		!isPtrEqual(pia.ServiceAccount, r.ko.Spec.ServiceAccount) {
+		return nil, nil
+	}
+
+	return resp.Associations[0].AssociationId, nil
+
+}
+
+func isPtrEqual(a, b *string) bool {
+	// we expect both to be non-nil, return false otherwise
+	if a == nil {
+		return false
+	}
+	if b == nil {
+		return false
+	}
+	return *a == *b
+}

--- a/pkg/resource/pod_identity_association/sdk.go
+++ b/pkg/resource/pod_identity_association/sdk.go
@@ -27,6 +27,7 @@ import (
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	"github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/eks"
@@ -62,6 +63,13 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+	// Retrieve podIdentityAssociation ID only during adoption
+	if r.ko.Status.AssociationID == nil && runtime.NeedAdoption(r) {
+		r.ko.Status.AssociationID, err = rm.getAssociationID(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+	}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/templates/hooks/pod_identity_association/sdk_read_one_pre_build_request.go.tpl
+++ b/templates/hooks/pod_identity_association/sdk_read_one_pre_build_request.go.tpl
@@ -1,0 +1,7 @@
+	// Retrieve podIdentityAssociation ID only during adoption 
+	if r.ko.Status.AssociationID == nil && runtime.NeedAdoption(r) {
+		r.ko.Status.AssociationID, err = rm.getAssociationID(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+	}


### PR DESCRIPTION
Issue [#2684](https://github.com/aws-controllers-k8s/community/issues/2684)

Description of changes:
With these changes, we allow users to use ClusterName, Namespace, and
ServiceAccount to adopt a PodIdentityAssociation resource when using
`adopt-or-create` if AssociationID is not provided.

Note: this will not work when using `adopt` adoption policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
