### PR TITLE
Fix incorrect delta comparison for ConfigurationValues

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-25T00:27:17Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
-  go_version: go1.26.2
-  version: v0.58.1
+  build_date: "2026-05-13T04:44:40Z"
+  build_hash: b061ffd6a5fa8ee4286c29b9f4bbac39f24f93ee
+  go_version: go1.26.0
+  version: v0.58.1-8-gb061ffd
 api_directory_checksum: 36ac52c0ff418b2773aafd6b784420b5851e7fea
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: bb6f57f5eabb8260946a99d61577c3caeeecc1d6
+  file_checksum: 1027e8961821c1fb147d0455e3e4650c5026e491
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -31,6 +31,8 @@ resources:
         references:
           resource: Cluster
           path: Spec.Name
+      ConfigurationValues:
+        is_document: true
       ServiceAccountRoleArn:
         references:
           service_name: iam

--- a/generator.yaml
+++ b/generator.yaml
@@ -31,6 +31,8 @@ resources:
         references:
           resource: Cluster
           path: Spec.Name
+      ConfigurationValues:
+        is_document: true
       ServiceAccountRoleArn:
         references:
           service_name: iam

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws-controllers-k8s/ec2-controller v1.1.0
 	github.com/aws-controllers-k8s/iam-controller v1.3.1
 	github.com/aws-controllers-k8s/kms-controller v1.0.9
-	github.com/aws-controllers-k8s/runtime v0.58.0
+	github.com/aws-controllers-k8s/runtime v0.58.2-0.20260512210412-61d58ad3edb8
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/aws/aws-sdk-go-v2 v1.41.2
 	github.com/aws/aws-sdk-go-v2/service/eks v1.80.0
@@ -55,7 +55,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/micahhausler/aws-iam-policy v0.4.4 // indirect
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aws-controllers-k8s/iam-controller v1.3.1 h1:/3yH3tAtSVAAt2ulIqsmutjW
 github.com/aws-controllers-k8s/iam-controller v1.3.1/go.mod h1:7nZzMtEN8xEL5fYhL9FKkBhqoP4QMmMp5x5dXDGwfYM=
 github.com/aws-controllers-k8s/kms-controller v1.0.9 h1:GZHSnuZBoWp9r6RaJ3siyDn5BRhDuaZJXtdBKeAiLSw=
 github.com/aws-controllers-k8s/kms-controller v1.0.9/go.mod h1:Pnz0d5sly7dUgmYMDJWSRIKASOujJFi/b8N2q1qCLqU=
-github.com/aws-controllers-k8s/runtime v0.58.0 h1:PbM3hsM5z66BSPTb2CBBElYmGF3EgSbUO88efLXxL78=
-github.com/aws-controllers-k8s/runtime v0.58.0/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/runtime v0.58.2-0.20260512210412-61d58ad3edb8 h1:QpT5HxytMq82Lfr7ouaWTBI7E/xHcmo4y6o00HuITUQ=
+github.com/aws-controllers-k8s/runtime v0.58.2-0.20260512210412-61d58ad3edb8/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.41.2 h1:LuT2rzqNQsauaGkPK/7813XxcZ3o3yePY0Iy891T2ls=
@@ -116,8 +116,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
-github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 h1:J1D4vj3/AVzVoo1allyJJD3mh7J6bPWXVoQHOBQ+p5Y=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/resource/addon/delta.go
+++ b/pkg/resource/addon/delta.go
@@ -70,7 +70,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.ConfigurationValues, b.ko.Spec.ConfigurationValues) {
 		delta.Add("Spec.ConfigurationValues", a.ko.Spec.ConfigurationValues, b.ko.Spec.ConfigurationValues)
 	} else if a.ko.Spec.ConfigurationValues != nil && b.ko.Spec.ConfigurationValues != nil {
-		if *a.ko.Spec.ConfigurationValues != *b.ko.Spec.ConfigurationValues {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.ConfigurationValues, *b.ko.Spec.ConfigurationValues); err != nil || !equal {
 			delta.Add("Spec.ConfigurationValues", a.ko.Spec.ConfigurationValues, b.ko.Spec.ConfigurationValues)
 		}
 	}

--- a/pkg/resource/addon/delta_test.go
+++ b/pkg/resource/addon/delta_test.go
@@ -1,0 +1,136 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package addon
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+
+	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
+)
+
+// helper to build a *resource with only ConfigurationValues set.
+func addonWithConfigurationValues(configValues *string) *resource {
+	return &resource{
+		ko: &svcapitypes.Addon{
+			Spec: svcapitypes.AddonSpec{
+				Name:                aws.String("test-addon"),
+				ClusterName:         aws.String("test-cluster"),
+				ConfigurationValues: configValues,
+			},
+		},
+	}
+}
+
+func TestNewResourceDelta_ConfigurationValues_JSONComparison(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  *string
+		latest   *string
+		wantDiff bool
+	}{
+		{
+			name:     "both nil produces no diff",
+			desired:  nil,
+			latest:   nil,
+			wantDiff: false,
+		},
+		{
+			name:     "desired nil latest non-nil produces diff",
+			desired:  nil,
+			latest:   aws.String(`{"key":"value"}`),
+			wantDiff: true,
+		},
+		{
+			name:     "desired non-nil latest nil produces diff",
+			desired:  aws.String(`{"key":"value"}`),
+			latest:   nil,
+			wantDiff: true,
+		},
+		{
+			name:     "identical JSON strings produce no diff",
+			desired:  aws.String(`{"key":"value"}`),
+			latest:   aws.String(`{"key":"value"}`),
+			wantDiff: false,
+		},
+		{
+			name:     "trailing newline from YAML block scalar produces no diff (issue 2869)",
+			desired:  aws.String("{\n  \"secrets-store-csi-driver\": {\n    \"syncSecret\": {\n      \"enabled\": true\n    }\n  }\n}\n"),
+			latest:   aws.String("{\n  \"secrets-store-csi-driver\": {\n    \"syncSecret\": {\n      \"enabled\": true\n    }\n  }\n}"),
+			wantDiff: false,
+		},
+		{
+			name:     "pretty vs compact JSON produces no diff (issue 2877)",
+			desired:  aws.String("{\n  \"notificationOrigin\": [\n    \"PRODUCT\"\n  ]\n}\n"),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			wantDiff: false,
+		},
+		{
+			name:     "different key ordering produces no diff",
+			desired:  aws.String(`{"b":2,"a":1}`),
+			latest:   aws.String(`{"a":1,"b":2}`),
+			wantDiff: false,
+		},
+		{
+			name:    "whitespace differences produce no diff",
+			desired: aws.String(`{"key":"value","nested":{"a":1}}`),
+			latest: aws.String(`{
+				"key": "value",
+				"nested": {
+					"a": 1
+				}
+			}`),
+			wantDiff: false,
+		},
+		{
+			name:     "different values produce diff",
+			desired:  aws.String(`{"key":"value1"}`),
+			latest:   aws.String(`{"key":"value2"}`),
+			wantDiff: true,
+		},
+		{
+			name:     "extra key produces diff",
+			desired:  aws.String(`{"a":1}`),
+			latest:   aws.String(`{"a":1,"b":2}`),
+			wantDiff: true,
+		},
+		{
+			name:     "missing key produces diff",
+			desired:  aws.String(`{"a":1,"b":2}`),
+			latest:   aws.String(`{"a":1}`),
+			wantDiff: true,
+		},
+		{
+			name:     "different nested values produce diff",
+			desired:  aws.String(`{"syncSecret":{"enabled":true}}`),
+			latest:   aws.String(`{"syncSecret":{"enabled":false}}`),
+			wantDiff: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := addonWithConfigurationValues(tt.desired)
+			latest := addonWithConfigurationValues(tt.latest)
+
+			delta := newResourceDelta(desired, latest)
+			hasDiff := delta.DifferentAt("Spec.ConfigurationValues")
+
+			assert.Equal(t, tt.wantDiff, hasDiff,
+				"DifferentAt(Spec.ConfigurationValues) = %v, want %v", hasDiff, tt.wantDiff)
+		})
+	}
+}


### PR DESCRIPTION
# Fix incorrect delta comparison for Addon ConfigurationValues

## Problem

The EKS controller was performing a simple string comparison on the `ConfigurationValues` field for Addons. This caused infinite reconciliation loops https://github.com/aws-controllers-k8s/community/issues/2877

## Solution

- Marked `ConfigurationValues` as `is_document: true` in `generator.yaml`, which triggers semantic JSON/YAML comparison via `ackcompare.DocumentEqual` from the ACK runtime.
- Updated the runtime dependency to `v0.58.2-0.20260512210412-61d58ad3edb8` which includes the `DocumentEqual` function.


All unit tests pass, covering nil handling, formatting equivalence, and real diff detection.