### PR TITLE
Fix failing e2e test

### DIFF
--- a/test/e2e/tests/test_addon.py
+++ b/test/e2e/tests/test_addon.py
@@ -131,7 +131,7 @@ class TestAddon:
             assert aws_res is not None
 
             assert aws_res["addon"]["addonName"] == addon_name
-            assert aws_res["addon"]["configurationValues"] == configuration_values
+            assert json.loads(aws_res["addon"]["configurationValues"]) == json.loads(configuration_values)
             assert aws_res["addon"]["addonArn"] is not None
         except eks_client.exceptions.ResourceNotFoundException:
             pytest.fail(f"Could not find Addon '{cr_name}' in EKS")


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- incorrectly using string compare to validate json documents. 
- Fix flaky e2e test with json parse before doing compare to avoid newline and white space issues. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
