### PR TITLE
fix: associate access policies on AccessEntry creation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-26T19:32:54Z"
-  build_hash: 016cc97b328515c8db205ad1091916a0cc66614b
+  build_date: "2026-07-02T15:04:10Z"
+  build_hash: 84c9b9904125e2182619e048d7e35d0f8700d20c
   go_version: go1.26.4
-  version: v0.60.0-2-g016cc97
+  version: v0.60.0-3-g84c9b99
 api_directory_checksum: 223ceb0e1212b81c2171ee1932a74a3b418540b4
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 20146e33a2063c52a6f7c94d595c562fa608fc28
+  file_checksum: 8cf48a6bb3b16cbe1eaf5480c36dacb3b6fa46bd
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -525,6 +525,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
+      sdk_create_post_set_output:
+        template_path: hooks/access_entry/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/access_entry/sdk_read_one_post_set_output.go.tpl
       sdk_update_pre_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -525,6 +525,8 @@ resources:
     hooks:
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
+      sdk_create_post_set_output:
+        template_path: hooks/access_entry/sdk_create_post_set_output.go.tpl
       sdk_read_one_post_set_output:
         template_path: hooks/access_entry/sdk_read_one_post_set_output.go.tpl
       sdk_update_pre_build_request:

--- a/pkg/resource/access_entry/sdk.go
+++ b/pkg/resource/access_entry/sdk.go
@@ -248,6 +248,11 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if desired.ko.Spec.AccessPolicies != nil {
+		msg := "Access policy update pending; resource will be requeued in 30 seconds"
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/access_entry/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/access_entry/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,4 @@
+        if desired.ko.Spec.AccessPolicies != nil {
+                msg := "Access policy update pending; resource will be requeued in 30 seconds"
+                ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
+        }


### PR DESCRIPTION
The sdkCreate function calls CreateAccessEntry but does not follow up with AssociateAccessPolicy calls. This means accessPolicies defined in the spec are silently ignored on creation and only applied on subsequent updates.


Issue #2917 https://github.com/aws-controllers-k8s/community/issues/2917

Description of changes:

Add a call to syncAccessPolicies at the end of sdkCreate to ensure policies are associated immediately after the access entry is created.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
