### PR TITLE
Add IAM Role references to EKS resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:04:49Z"
+  build_date: "2026-06-24T18:39:09Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.60.0
-api_directory_checksum: 2cfde97f4a0ccd1bed9f1bf05a0e8d85d5f2cd3e
+api_directory_checksum: d70db4d0393696a439c4dac24b5b265d8b28d3d0
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: f1942e70e9005b385b9d1472dffc8fd182f64d11
+  file_checksum: d5776037b4bf1291dc7c62e4fbda96f47eef5c4b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -38,6 +38,11 @@ resources:
           service_name: iam
           resource: Role
           path: Status.ACKResourceMetadata.ARN
+      PodIdentityAssociations.RoleARN:
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       PodIdentityAssociations:
         set:
         - ignore: true
@@ -461,6 +466,11 @@ resources:
           path: Spec.Name
         is_primary_key: true
       RoleARN:
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
+      TargetRoleARN:
         references:
           service_name: iam
           resource: Role

--- a/apis/v1alpha1/pod_identity_association.go
+++ b/apis/v1alpha1/pod_identity_association.go
@@ -122,7 +122,8 @@ type PodIdentityAssociationSpec struct {
 	// IAM role fields, EKS will perform role chaining to ensure your application
 	// gets the required permissions. This means Role A will assume Role B, allowing
 	// your Pods to securely access resources like S3 buckets in the target account.
-	TargetRoleARN *string `json:"targetRoleARN,omitempty"`
+	TargetRoleARN *string                                  `json:"targetRoleARN,omitempty"`
+	TargetRoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetRoleRef,omitempty"`
 }
 
 // PodIdentityAssociationStatus defines the observed state of PodIdentityAssociation

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -135,8 +135,10 @@ type AddonIssue struct {
 // EKS Pod Identity (https://docs.aws.amazon.com/eks/latest/userguide/add-ons-iam.html)
 // in the Amazon EKS User Guide.
 type AddonPodIdentityAssociations struct {
-	RoleARN        *string `json:"roleARN,omitempty"`
-	ServiceAccount *string `json:"serviceAccount,omitempty"`
+	RoleARN *string `json:"roleARN,omitempty"`
+	// Reference field for RoleARN
+	RoleRef        *ackv1alpha1.AWSResourceReferenceWrapper `json:"roleRef,omitempty"`
+	ServiceAccount *string                                  `json:"serviceAccount,omitempty"`
 }
 
 // Information about how to configure IAM for an add-on.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -561,6 +561,11 @@ func (in *AddonPodIdentityAssociations) DeepCopyInto(out *AddonPodIdentityAssoci
 		*out = new(string)
 		**out = **in
 	}
+	if in.RoleRef != nil {
+		in, out := &in.RoleRef, &out.RoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
 		*out = new(string)
@@ -4660,6 +4665,11 @@ func (in *PodIdentityAssociationSpec) DeepCopyInto(out *PodIdentityAssociationSp
 		in, out := &in.TargetRoleARN, &out.TargetRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.TargetRoleRef != nil {
+		in, out := &in.TargetRoleRef, &out.TargetRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/eks.services.k8s.aws_addons.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_addons.yaml
@@ -130,6 +130,20 @@ spec:
                   properties:
                     roleARN:
                       type: string
+                    roleRef:
+                      description: Reference field for RoleARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
                     serviceAccount:
                       type: string
                   type: object

--- a/config/crd/bases/eks.services.k8s.aws_podidentityassociations.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_podidentityassociations.yaml
@@ -215,6 +215,23 @@ spec:
                   gets the required permissions. This means Role A will assume Role B, allowing
                   your Pods to securely access resources like S3 buckets in the target account.
                 type: string
+              targetRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
             required:
             - namespace
             - serviceAccount

--- a/generator.yaml
+++ b/generator.yaml
@@ -38,6 +38,11 @@ resources:
           service_name: iam
           resource: Role
           path: Status.ACKResourceMetadata.ARN
+      PodIdentityAssociations.RoleARN:
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       PodIdentityAssociations:
         set:
         - ignore: true
@@ -461,6 +466,11 @@ resources:
           path: Spec.Name
         is_primary_key: true
       RoleARN:
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
+      TargetRoleARN:
         references:
           service_name: iam
           resource: Role

--- a/helm/crds/eks.services.k8s.aws_addons.yaml
+++ b/helm/crds/eks.services.k8s.aws_addons.yaml
@@ -130,6 +130,20 @@ spec:
                   properties:
                     roleARN:
                       type: string
+                    roleRef:
+                      description: Reference field for RoleARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
                     serviceAccount:
                       type: string
                   type: object

--- a/helm/crds/eks.services.k8s.aws_podidentityassociations.yaml
+++ b/helm/crds/eks.services.k8s.aws_podidentityassociations.yaml
@@ -215,6 +215,23 @@ spec:
                   gets the required permissions. This means Role A will assume Role B, allowing
                   your Pods to securely access resources like S3 buckets in the target account.
                 type: string
+              targetRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
             required:
             - namespace
             - serviceAccount

--- a/pkg/resource/addon/hooks_test.go
+++ b/pkg/resource/addon/hooks_test.go
@@ -41,10 +41,10 @@ func TestEqualPodIdentityAssociation(t *testing.T) {
 			"non-empty slices",
 			args{
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
 				},
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
 				},
 			},
 			true,
@@ -53,14 +53,14 @@ func TestEqualPodIdentityAssociation(t *testing.T) {
 			"3 elements",
 			args{
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn3"), ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
 				},
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn3"), ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
 				},
 			},
 			true,
@@ -69,14 +69,14 @@ func TestEqualPodIdentityAssociation(t *testing.T) {
 			"3 elements, different order",
 			args{
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn3"), ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
 				},
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn3"), ptr("serviceaccount3")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn"), ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
 				},
 			},
 			true,
@@ -85,13 +85,13 @@ func TestEqualPodIdentityAssociation(t *testing.T) {
 			"different sizes",
 			args{
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn3"), ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
 				},
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn3"), ptr("serviceaccount3")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
 				},
 			},
 			false,
@@ -100,14 +100,14 @@ func TestEqualPodIdentityAssociation(t *testing.T) {
 			"same size, different elements",
 			args{
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn"), ptr("serviceaccount")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn3"), ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn"), ServiceAccount: ptr("serviceaccount")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
 				},
 				[]*v1alpha1.AddonPodIdentityAssociations{
-					{ptr("rolearn3"), ptr("serviceaccount3")},
-					{ptr("rolearn2"), ptr("serviceaccount2")},
-					{ptr("rolearn4"), ptr("serviceaccount4")},
+					{RoleARN: ptr("rolearn3"), ServiceAccount: ptr("serviceaccount3")},
+					{RoleARN: ptr("rolearn2"), ServiceAccount: ptr("serviceaccount2")},
+					{RoleARN: ptr("rolearn4"), ServiceAccount: ptr("serviceaccount4")},
 				},
 			},
 			false,
@@ -167,7 +167,7 @@ func TestFormatPodIdentityAssociation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := formatPodIdentityAssociation(&v1alpha1.AddonPodIdentityAssociations{tt.args.roleARN, tt.args.serviceAccount}); got != tt.want {
+			if got := formatPodIdentityAssociation(&v1alpha1.AddonPodIdentityAssociations{RoleARN: tt.args.roleARN, ServiceAccount: tt.args.serviceAccount}); got != tt.want {
 				t.Errorf("FormatPodIdentityAssociation() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/resource/addon/references.go
+++ b/pkg/resource/addon/references.go
@@ -35,6 +35,9 @@ import (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -44,6 +47,12 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.ClusterRef != nil {
 		ko.Spec.ClusterName = nil
+	}
+
+	for f0idx, f0iter := range ko.Spec.PodIdentityAssociations {
+		if f0iter.RoleRef != nil {
+			ko.Spec.PodIdentityAssociations[f0idx].RoleARN = nil
+		}
 	}
 
 	if ko.Spec.ServiceAccountRoleRef != nil {
@@ -75,6 +84,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForPodIdentityAssociations_RoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForServiceAccountRoleARN(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -93,6 +108,12 @@ func validateReferenceFields(ko *svcapitypes.Addon) error {
 	}
 	if ko.Spec.ClusterRef == nil && ko.Spec.ClusterName == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterRef")
+	}
+
+	for _, f0iter := range ko.Spec.PodIdentityAssociations {
+		if f0iter.RoleRef != nil && f0iter.RoleARN != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("PodIdentityAssociations.RoleARN", "PodIdentityAssociations.RoleRef")
+		}
 	}
 
 	if ko.Spec.ServiceAccountRoleRef != nil && ko.Spec.ServiceAccountRoleARN != nil {
@@ -192,38 +213,40 @@ func getReferencedResourceState_Cluster(
 	return nil
 }
 
-// resolveReferenceForServiceAccountRoleARN reads the resource referenced
-// from ServiceAccountRoleRef field and sets the ServiceAccountRoleARN
+// resolveReferenceForPodIdentityAssociations_RoleARN reads the resource referenced
+// from PodIdentityAssociations.RoleRef field and sets the PodIdentityAssociations.RoleARN
 // from referenced resource. Returns a boolean indicating whether a reference
 // contains references, or an error
-func (rm *resourceManager) resolveReferenceForServiceAccountRoleARN(
+func (rm *resourceManager) resolveReferenceForPodIdentityAssociations_RoleARN(
 	ctx context.Context,
 	apiReader client.Reader,
 	ko *svcapitypes.Addon,
 ) (hasReferences bool, err error) {
-	if ko.Spec.ServiceAccountRoleRef != nil && ko.Spec.ServiceAccountRoleRef.From != nil {
-		hasReferences = true
-		arr := ko.Spec.ServiceAccountRoleRef.From
-		if arr.Name == nil || *arr.Name == "" {
-			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ServiceAccountRoleRef")
+	for f0idx, f0iter := range ko.Spec.PodIdentityAssociations {
+		if f0iter.RoleRef != nil && f0iter.RoleRef.From != nil {
+			hasReferences = true
+			arr := f0iter.RoleRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PodIdentityAssociations.RoleRef")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &iamapitypes.Role{}
+			if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.PodIdentityAssociations[f0idx].RoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
 		}
-		namespace, err := ackrt.ResolveCrossNamespaceReference(
-			ctx,
-			rm.cfg.EnableCrossNamespace,
-			&ko.Status.Conditions,
-			ackrt.CrossNamespaceRefKindResource,
-			ko.ObjectMeta.GetNamespace(),
-			arr.Namespace,
-			*arr.Name,
-		)
-		if err != nil {
-			return hasReferences, err
-		}
-		obj := &iamapitypes.Role{}
-		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return hasReferences, err
-		}
-		ko.Spec.ServiceAccountRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
 	return hasReferences, nil
@@ -281,4 +304,41 @@ func getReferencedResourceState_Role(
 			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
+}
+
+// resolveReferenceForServiceAccountRoleARN reads the resource referenced
+// from ServiceAccountRoleRef field and sets the ServiceAccountRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForServiceAccountRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Addon,
+) (hasReferences bool, err error) {
+	if ko.Spec.ServiceAccountRoleRef != nil && ko.Spec.ServiceAccountRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ServiceAccountRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ServiceAccountRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ServiceAccountRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
 }

--- a/pkg/resource/pod_identity_association/delta.go
+++ b/pkg/resource/pod_identity_association/delta.go
@@ -109,6 +109,9 @@ func newResourceDelta(
 			delta.Add("Spec.TargetRoleARN", a.ko.Spec.TargetRoleARN, b.ko.Spec.TargetRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.TargetRoleRef, b.ko.Spec.TargetRoleRef) {
+		delta.Add("Spec.TargetRoleRef", a.ko.Spec.TargetRoleRef, b.ko.Spec.TargetRoleRef)
+	}
 
 	return delta
 }

--- a/pkg/resource/pod_identity_association/references.go
+++ b/pkg/resource/pod_identity_association/references.go
@@ -35,6 +35,9 @@ import (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -48,6 +51,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.RoleRef != nil {
 		ko.Spec.RoleARN = nil
+	}
+
+	if ko.Spec.TargetRoleRef != nil {
+		ko.Spec.TargetRoleARN = nil
 	}
 
 	return &resource{ko}
@@ -81,6 +88,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForTargetRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -100,6 +113,10 @@ func validateReferenceFields(ko *svcapitypes.PodIdentityAssociation) error {
 	}
 	if ko.Spec.RoleRef == nil && ko.Spec.RoleARN == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("RoleARN", "RoleRef")
+	}
+
+	if ko.Spec.TargetRoleRef != nil && ko.Spec.TargetRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("TargetRoleARN", "TargetRoleRef")
 	}
 	return nil
 }
@@ -284,4 +301,41 @@ func getReferencedResourceState_Role(
 			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
+}
+
+// resolveReferenceForTargetRoleARN reads the resource referenced
+// from TargetRoleRef field and sets the TargetRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForTargetRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.PodIdentityAssociation,
+) (hasReferences bool, err error) {
+	if ko.Spec.TargetRoleRef != nil && ko.Spec.TargetRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.TargetRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: TargetRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.TargetRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
 }


### PR DESCRIPTION
## Description

Adds ACK cross-resource references to `iam/Role` for two EKS fields that accept an IAM Role ARN. This lets users reference an ACK-managed `iam.Role` resource by name instead of hardcoding an ARN.

| Resource | Field | Reference field added | Target |
|----------|-------|-----------------------|--------|
| `Addon` | `podIdentityAssociations[].roleARN` | `podIdentityAssociations[].roleRef` | iam/Role |
| `PodIdentityAssociation` | `targetRoleARN` | `targetRoleRef` | iam/Role |

All references use `path: Status.ACKResourceMetadata.ARN`, mirroring the existing `iam/Role` references in this repo (e.g. `Cluster.roleARN`, `Nodegroup.nodeRole`, `FargateProfile.podExecutionRoleARN`, `PodIdentityAssociation.roleARN`).

## Changes
- Edited root `generator.yaml` to add the two references.
- Regenerated controller artifacts with code-generator v0.60.0 (`AWS_SDK_GO_VERSION=v1.41.2`).

## Verification
- `make build-controller` succeeded.
- `go build ./cmd/controller` compiles cleanly.
- `go test ./...` passes.

## Notes
The following candidates were intentionally skipped:
- `Cluster.computeConfig.nodeRoleARN` — nested struct reference overwrite bug (controller read-back populates concrete ARN from Describe, losing the ref). Needs code-generator fix.
- `AccessEntry.accessPolicies.policyARN` — AWS-managed EKS access policy, not an ACK resource.
- `AccessEntry.principalARN` — ambiguous IAM principal (user or role).
- `Capability.configuration.argoCD.rbacRoleMappings.role` — an ArgoCD RBAC role string, not an IAM role.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.