### PR TITLE
fix: converge AccessEntry Synced=True after access policy update

### DIFF
--- a/pkg/resource/access_entry/sdk.go
+++ b/pkg/resource/access_entry/sdk.go
@@ -299,6 +299,15 @@ func (rm *resourceManager) sdkUpdate(
 	defer func() {
 		exit(err)
 	}()
+	// Carry the latest observed status (including conditions) onto a copy of
+	// desired so the returned resource reflects the observed state rather than
+	// the stale create-time "Access policy update pending" ResourceSynced=False
+	// condition. AccessPolicies are applied via AssociateAccessPolicy side-effect
+	// calls (not UpdateAccessEntry); returning bare `desired` here leaves that
+	// stale condition in place and the resource stays Synced=False until the next
+	// full resync (up to 10h). See aws-controllers-k8s/community#2967.
+	updatedDesired := rm.concreteResource(desired.DeepCopy())
+	updatedDesired.SetStatus(latest)
 	if delta.DifferentAt("Spec.AccessPolicies") {
 		err := rm.syncAccessPolicies(ctx, desired, latest)
 		if err != nil {
@@ -316,8 +325,9 @@ func (rm *resourceManager) sdkUpdate(
 		}
 	}
 	if !delta.DifferentExcept("Spec.AccessPolicies", "Spec.Tags") {
-		return desired, nil
+		return updatedDesired, nil
 	}
+
 	input, err := rm.newUpdateRequestPayload(ctx, desired, delta)
 	if err != nil {
 		return nil, err

--- a/pkg/resource/access_entry/sdk.go
+++ b/pkg/resource/access_entry/sdk.go
@@ -299,13 +299,8 @@ func (rm *resourceManager) sdkUpdate(
 	defer func() {
 		exit(err)
 	}()
-	// Carry the latest observed status (including conditions) onto a copy of
-	// desired so the returned resource reflects the observed state rather than
-	// the stale create-time "Access policy update pending" ResourceSynced=False
-	// condition. AccessPolicies are applied via AssociateAccessPolicy side-effect
-	// calls (not UpdateAccessEntry); returning bare `desired` here leaves that
-	// stale condition in place and the resource stays Synced=False until the next
-	// full resync (up to 10h). See aws-controllers-k8s/community#2967.
+	// Carry the latest observed status so the update path doesn't return the
+	// stale create-time ResourceSynced=False condition (community#2967).
 	updatedDesired := rm.concreteResource(desired.DeepCopy())
 	updatedDesired.SetStatus(latest)
 	if delta.DifferentAt("Spec.AccessPolicies") {

--- a/templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl
@@ -1,10 +1,5 @@
-	// Carry the latest observed status (including conditions) onto a copy of
-	// desired so the returned resource reflects the observed state rather than
-	// the stale create-time "Access policy update pending" ResourceSynced=False
-	// condition. AccessPolicies are applied via AssociateAccessPolicy side-effect
-	// calls (not UpdateAccessEntry); returning bare `desired` here leaves that
-	// stale condition in place and the resource stays Synced=False until the next
-	// full resync (up to 10h). See aws-controllers-k8s/community#2967.
+	// Carry the latest observed status so the update path doesn't return the
+	// stale create-time ResourceSynced=False condition (community#2967).
 	updatedDesired := rm.concreteResource(desired.DeepCopy())
 	updatedDesired.SetStatus(latest)
 	if delta.DifferentAt("Spec.AccessPolicies") {

--- a/templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl
@@ -1,3 +1,12 @@
+	// Carry the latest observed status (including conditions) onto a copy of
+	// desired so the returned resource reflects the observed state rather than
+	// the stale create-time "Access policy update pending" ResourceSynced=False
+	// condition. AccessPolicies are applied via AssociateAccessPolicy side-effect
+	// calls (not UpdateAccessEntry); returning bare `desired` here leaves that
+	// stale condition in place and the resource stays Synced=False until the next
+	// full resync (up to 10h). See aws-controllers-k8s/community#2967.
+	updatedDesired := rm.concreteResource(desired.DeepCopy())
+	updatedDesired.SetStatus(latest)
 	if delta.DifferentAt("Spec.AccessPolicies") {
 		err := rm.syncAccessPolicies(ctx, desired, latest)
 		if err != nil {
@@ -15,5 +24,5 @@
 		}
 	}
     if !delta.DifferentExcept("Spec.AccessPolicies", "Spec.Tags"){
-        return desired, nil
+        return updatedDesired, nil
     }


### PR DESCRIPTION
## Description

Fixes the AccessEntry `ResourceSynced` condition getting stuck at `False` after its access policies are successfully applied.

Ref: aws-controllers-k8s/community#2967

## Symptom

After creating an `AccessEntry` that specifies `spec.accessPolicies`, the resource can remain `SYNCED=False` indefinitely with the message:

> Access policy update pending; resource will be requeued in 30 seconds

even though the policy **is** attached in AWS (`aws eks list-associated-access-policies` shows it). A controller restart clears it every time. This is a **status-reporting** bug — the AWS state is correct, only the CR's `Synced` condition is wrong.

## Root cause

`AccessPolicies` are not part of `UpdateAccessEntry`; they are applied out-of-band via `AssociateAccessPolicy` / `DisassociateAccessPolicy`. The `sdk_update_pre_build_request` hook does that work and then short-circuits the update:

```go
if !delta.DifferentExcept("Spec.AccessPolicies", "Spec.Tags") {
    return desired, nil
}
```

The create path intentionally sets `ResourceSynced=False` ("Access policy update pending…") so the runtime requeues and the policies get associated on the follow-up reconcile. The problem is what the update path returns: the bare `desired` resource carries that create-time `ResourceSynced=False` condition through to the status patch. The reconciler then requeues only on the normal resync interval (up to 10h), so the stale `False` persists until then.

A controller restart appears to "fix" it because the post-restart reconcile observes the policy already attached, produces an **empty delta**, skips the update path entirely, and lets the runtime recompute the condition via `IsSynced()` → `True`.

The intermittency reported in the issue comes from timing: if `ListAssociatedAccessPolicies` happens to already reflect the policy on the next reconcile (empty delta), the resource converges; if an update fires first, it sticks.

## Fix

Return the resource with the **latest observed status** instead of the create-time `desired` status, so the reconciler recomputes and persists `ResourceSynced=True` in the same update cycle. This mirrors the existing pattern used by the wafv2 `WebACL` update hook.

```go
updatedDesired := rm.concreteResource(desired.DeepCopy())
updatedDesired.SetStatus(latest)
...
if !delta.DifferentExcept("Spec.AccessPolicies", "Spec.Tags") {
    return updatedDesired, nil
}
```

The change is in the hook template (`templates/hooks/access_entry/sdk_update_pre_build_request.go.tpl`); `pkg/resource/access_entry/sdk.go` is regenerated output.

## Validation (on a live EKS cluster)

Built and deployed both the current `main` and the fix, verifying the running pod image tag matched the exact commit each time.

**Before (current `main`):** create an AccessEntry with `accessPolicies` →
- `created new resource` → `Synced=False`, requeue 30s
- update reconcile: `associating access policy` → `updated resource` → requeue **36000s (10h)**
- status patch persisted `Synced=False` (create-time message, unchanged transition time)
- `list-associated-access-policies`: policy **is** attached
- result: **stuck `Synced=False`**; `kubectl rollout restart` → flips to `Synced=True`

**After (this fix):** 5/5 fresh AccessEntries →
- same create → update sequence, but the update reconcile's status patch persisted `Synced=True` ("Resource synced successfully")
- converged automatically in ~5s, **no restart needed**; policies attached in AWS

## Alternatives considered

- **Short requeue after policy sync** (return a `requeue.NeededAfter` so the next empty-delta reconcile converges). This also works, but adds an extra reconcile round-trip and a bespoke requeue instead of reusing the established status-carry pattern. The status-carry approach converges in a single cycle.

## Test plan

- [x] `go build ./...`
- [x] Manual end-to-end on an `API_AND_CONFIG_MAP` EKS cluster (create AccessEntry with `accessPolicies`, confirm `Synced=True` without restart, confirm policy attached in AWS, delete cleanly)
- [ ] e2e coverage asserting the `Synced` condition after an access-policy update (follow-up)
