### PR TITLE
fix: skip DeletionProtection update when desired value is nil

### DIFF
--- a/pkg/resource/cluster/hook.go
+++ b/pkg/resource/cluster/hook.go
@@ -184,6 +184,9 @@ func (rm *resourceManager) clusterInUse(ctx context.Context, r *resource) (bool,
 	return (nodes != nil && len(nodes.Nodegroups) > 0), nil
 }
 
+// customPreCompare ensures that default values of nil-able types are
+// appropriately replaced with empty maps or structs depending on the default
+// output of the SDK.
 func customPreCompare(
 	a *resource,
 	b *resource,
@@ -771,6 +774,12 @@ func (rm *resourceManager) updateDeletionProtection(
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.updateDeletionProtection")
 	defer exit(err)
+
+	// Sending a nil DeletionProtection produces an UpdateClusterConfig request
+	// carrying no update type, which EKS rejects with InvalidParameterException
+	if r.ko.Spec.DeletionProtection == nil {
+		return nil
+	}
 
 	input := &svcsdk.UpdateClusterConfigInput{
 		Name:               r.ko.Spec.Name,

--- a/pkg/resource/cluster/hook_test.go
+++ b/pkg/resource/cluster/hook_test.go
@@ -1,0 +1,89 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	svcapitypes "github.com/aws-controllers-k8s/eks-controller/apis/v1alpha1"
+)
+
+func clusterWithDeletionProtection(name string, dp *bool) *resource {
+	return &resource{
+		ko: &svcapitypes.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "test",
+			},
+			Spec: svcapitypes.ClusterSpec{
+				Name:               aws.String(name),
+				DeletionProtection: dp,
+			},
+		},
+	}
+}
+
+// TestUpdateDeletionProtectionNilIsNoOp is a regression test for a bug that
+// prevented clusters from being deleted.
+//
+// DeletionProtection is configured with `pre_delete_include: true`, so on
+// delete the runtime computes DeltaForPreDelete(desired, observed). When the
+// user never set the field, desired is nil while EKS reports false. The
+// generated delta flags that as a difference and the merged resource it
+// returns carries the nil through to customUpdate, which then called
+// UpdateClusterConfig with a nil DeletionProtection -- a request with no
+// update type, rejected by EKS with:
+//
+//	InvalidParameterException: The type for cluster update was not provided.
+//
+// On the pre-delete path that error is fatal: the cluster is never deleted.
+//
+// updateDeletionProtection must therefore treat a nil value as a no-op rather
+// than relying on the delta alone. The resourceManager here has a nil sdkapi,
+// so the test fails loudly (panic) if the AWS call is ever reached.
+func TestUpdateDeletionProtectionNilIsNoOp(t *testing.T) {
+	rm := &resourceManager{}
+	desired := clusterWithDeletionProtection("test-cluster", nil)
+
+	require.NotPanics(t, func() {
+		err := rm.updateDeletionProtection(context.Background(), desired)
+		assert.NoError(t, err)
+	}, "updateDeletionProtection must not call the EKS API for a nil DeletionProtection")
+}
+
+// TestDeletionProtectionDeltaFlagsNilDesired documents the generated-delta
+// behaviour that makes the guard in updateDeletionProtection necessary. If
+// ack-generate ever stops reporting nil-desired vs non-nil-observed as a
+// difference, this test will fail and the guard can be revisited.
+func TestDeletionProtectionDeltaFlagsNilDesired(t *testing.T) {
+	desired := clusterWithDeletionProtection("test-cluster", nil)
+	observed := clusterWithDeletionProtection("test-cluster", aws.Bool(false))
+
+	preDeleteDelta, merged := newResourceDeltaForPreDelete(desired, observed)
+
+	assert.True(
+		t, preDeleteDelta.DifferentAt("Spec.DeletionProtection"),
+		"pre-delete delta is expected to flag nil desired vs false observed",
+	)
+	assert.Nil(
+		t, merged.ko.Spec.DeletionProtection,
+		"merged pre-delete resource carries the nil desired value into customUpdate",
+	)
+}


### PR DESCRIPTION
DeletionProtection is configured with pre_delete_include, so on delete the runtime compares desired vs observed. When the user never sets the field, desired is nil while EKS reports false. The generated delta flags that as a difference and the merged pre-delete resource carries the nil into customUpdate, which issued UpdateClusterConfig with no update type. EKS rejects the request, and on the pre-delete path that error is fatal: the cluster is never deleted. This broke our e2e tests, as the cluster couldn't be deleted.

The guard in updateDeletionProtection, matching how updateComputeConfig nil-checks its input fields. Adds regression tests.
