### PR TITLE
feat(capability): Add Cluster reference for clusterName

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-08-07T17:49:33Z"
-  build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
+  build_date: "2026-08-13T16:33:52Z"
+  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
-  version: v0.62.0
+  version: v0.62.1
 api_directory_checksum: 2b5287d0ef597d7039841a4cb7f7ffcb11e36bf8
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-08-13T22:03:34Z"
-  build_hash: 3dfc7a1e4135d59e6b1ecf6955ab1df4e829c9b5
+  build_date: "2026-08-13T22:21:15Z"
+  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
-  version: v0.62.1-2-g3dfc7a1-dirty
+  version: v0.62.1
 api_directory_checksum: c0a34b2df57fed9f6d2e79c861b0b52a8520dcb5
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-13T16:33:52Z"
+  build_date: "2026-08-13T16:37:49Z"
   build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
   version: v0.62.1
-api_directory_checksum: 2b5287d0ef597d7039841a4cb7f7ffcb11e36bf8
+api_directory_checksum: d850e61cbd2e989b4f613bd16a0a7f6e3651c567
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 5a8408f5d7d6b65570ded0a2505a15c2d89d2ab1
+  file_checksum: 44d2ecd9f8f95c6573b49e0653478a702af2a1c7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/capability.go
+++ b/apis/v1alpha1/capability.go
@@ -28,8 +28,8 @@ type CapabilitySpec struct {
 
 	// The name of the Amazon EKS cluster where you want to create the capability.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
-	// +kubebuilder:validation:Required
-	ClusterName *string `json:"clusterName"`
+	ClusterName *string                                  `json:"clusterName,omitempty"`
+	ClusterRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"clusterRef,omitempty"`
 	// The configuration settings for the capability. The structure of this object
 	// varies depending on the capability type. For Argo CD capabilities, you can
 	// configure IAM Identity CenterIAM; Identity Center integration, RBAC role

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -622,6 +622,9 @@ resources:
         is_immutable: true
       ClusterName:
         is_immutable: true
+        references:
+          resource: Cluster
+          path: Spec.Name
 ignore:
   resource_names:
   - EksAnywhereSubscription

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1403,6 +1403,11 @@ func (in *CapabilitySpec) DeepCopyInto(out *CapabilitySpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClusterRef != nil {
+		in, out := &in.ClusterRef, &out.ClusterRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Configuration != nil {
 		in, out := &in.Configuration, &out.Configuration
 		*out = new(CapabilityConfigurationRequest)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"os"
+	goruntime "runtime"
+	"runtime/debug"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
@@ -60,6 +62,21 @@ var (
 	scheme             = runtime.NewScheme()
 	setupLog           = ctrlrt.Log.WithName("setup")
 )
+
+// depVersion returns the module version of the given dependency import path,
+// as recorded in the binary's build info, or "unknown" if it cannot be found.
+func depVersion(path string) string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == path {
+			return dep.Version
+		}
+	}
+	return "unknown"
+}
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -156,6 +173,17 @@ func main() {
 	setupLog.Info(
 		"initializing service controller",
 		"aws.service", awsServiceAlias,
+		"version", version.GitVersion,
+	)
+	setupLog.V(1).Info(
+		"build details",
+		"aws.service", awsServiceAlias,
+		"gitCommit", version.GitCommit,
+		"buildDate", version.BuildDate,
+		"goVersion", goruntime.Version(),
+		"ackGenerateVersion", version.ACKGenerateVersion,
+		"ackRuntimeVersion", depVersion("github.com/aws-controllers-k8s/runtime"),
+		"awsSDKGoV2Version", depVersion("github.com/aws/aws-sdk-go-v2"),
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup,

--- a/config/crd/bases/eks.services.k8s.aws_capabilities.yaml
+++ b/config/crd/bases/eks.services.k8s.aws_capabilities.yaml
@@ -50,6 +50,23 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              clusterRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               configuration:
                 description: |-
                   The configuration settings for the capability. The structure of this object
@@ -182,7 +199,6 @@ spec:
                 - message: Value is immutable once set
                   rule: self == oldSelf
             required:
-            - clusterName
             - deletePropagationPolicy
             - name
             - type

--- a/generator.yaml
+++ b/generator.yaml
@@ -622,6 +622,9 @@ resources:
         is_immutable: true
       ClusterName:
         is_immutable: true
+        references:
+          resource: Cluster
+          path: Spec.Name
 ignore:
   resource_names:
   - EksAnywhereSubscription

--- a/helm/crds/eks.services.k8s.aws_capabilities.yaml
+++ b/helm/crds/eks.services.k8s.aws_capabilities.yaml
@@ -50,6 +50,23 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              clusterRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               configuration:
                 description: |-
                   The configuration settings for the capability. The structure of this object
@@ -182,7 +199,6 @@ spec:
                 - message: Value is immutable once set
                   rule: self == oldSelf
             required:
-            - clusterName
             - deletePropagationPolicy
             - name
             - type

--- a/pkg/resource/capability/delta.go
+++ b/pkg/resource/capability/delta.go
@@ -49,6 +49,9 @@ func newResourceDelta(
 			delta.Add("Spec.ClusterName", a.ko.Spec.ClusterName, b.ko.Spec.ClusterName)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ClusterRef, b.ko.Spec.ClusterRef) {
+		delta.Add("Spec.ClusterRef", a.ko.Spec.ClusterRef, b.ko.Spec.ClusterRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Configuration, b.ko.Spec.Configuration) {
 		delta.Add("Spec.Configuration", a.ko.Spec.Configuration, b.ko.Spec.Configuration)
 	} else if a.ko.Spec.Configuration != nil && b.ko.Spec.Configuration != nil {

--- a/pkg/resource/capability/references.go
+++ b/pkg/resource/capability/references.go
@@ -42,6 +42,10 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
+	if ko.Spec.ClusterRef != nil {
+		ko.Spec.ClusterName = nil
+	}
+
 	if ko.Spec.RoleRef != nil {
 		ko.Spec.RoleARN = nil
 	}
@@ -65,6 +69,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForClusterName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForRoleARN(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -78,11 +88,109 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Capability) error {
 
+	if ko.Spec.ClusterRef != nil && ko.Spec.ClusterName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ClusterName", "ClusterRef")
+	}
+	if ko.Spec.ClusterRef == nil && ko.Spec.ClusterName == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("ClusterName", "ClusterRef")
+	}
+
 	if ko.Spec.RoleRef != nil && ko.Spec.RoleARN != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("RoleARN", "RoleRef")
 	}
 	if ko.Spec.RoleRef == nil && ko.Spec.RoleARN == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("RoleARN", "RoleRef")
+	}
+	return nil
+}
+
+// resolveReferenceForClusterName reads the resource referenced
+// from ClusterRef field and sets the ClusterName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForClusterName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Capability,
+) (hasReferences bool, err error) {
+	if ko.Spec.ClusterRef != nil && ko.Spec.ClusterRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ClusterRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ClusterRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Cluster{}
+		if err := getReferencedResourceState_Cluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ClusterName = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Cluster looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Cluster(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Cluster,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Cluster",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Cluster",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Cluster",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Cluster",
+			namespace, name,
+			"Spec.Name")
 	}
 	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,8 +15,18 @@
 
 package version
 
+// GitVersion, GitCommit, and BuildDate describe the service controller build
+// and are injected at controller build time via -ldflags.
 var (
 	GitVersion string
 	GitCommit  string
 	BuildDate  string
+)
+
+// ACKGenerateVersion and ACKGenerateBuildDate identify the ack-generate build
+// that generated this controller's code. They are baked in at code-generation
+// time and are immutable for the life of the generated code.
+const (
+	ACKGenerateVersion   = "v0.62.1"
+	ACKGenerateBuildDate = "2026-08-13T16:33:52Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1-2-g3dfc7a1-dirty"
-	ACKGenerateBuildDate = "2026-08-13T22:03:34Z"
+	ACKGenerateVersion   = "v0.62.1"
+	ACKGenerateBuildDate = "2026-08-13T22:21:15Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T16:33:52Z"
+	ACKGenerateBuildDate = "2026-08-13T16:37:49Z"
 )


### PR DESCRIPTION
Adds cross-resource references to 1 top-level field on `Capability` in `eks-controller`.

Every field here is a **top-level** spec field (not nested in a struct or list) whose target Kind is confirmed ACK-managed. None needs `set: ignore`, `late_initialize`, or `skip_resource_state_validations`.

### Fields Added

| # | Field (`generator.yaml` path) | Target | `path` |
| --- | --- | --- | --- |
| 1 | `Capability.ClusterName` | `Cluster` (same-service) | `Spec.Name` |

### Verification

Deployed this branch to a dev EKS cluster (`us-west-2`) with `ack-workspace deploy eks --resync-period 60` and exercised the references against real AWS resources.

This is the **lightweight** check: the reference resolves and the resource reaches `Synced`. It is deliberately not the full pass matrix — no multi-resync delta count and no reference-preservation check — so rows below say nothing about long-run delta behaviour.

| # | Reference | RefsResolved | Synced | Concrete absent | `*Ref` present | Result |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | `Capability.clusterRef` | ✅ | ✅ | ✅ | ✅ | **PASS** |

**Summary: 1 PASS of 1.**

- `Capability.clusterRef` — capability ACTIVE on the referenced cluster

Exercised against an ACK-managed EKS `Cluster`; the `Capability` reached `status: ACTIVE` and
`Synced=True`. `clusterName` also left the served CRD's `required` list (now
`['deletePropagationPolicy','name','type']`), so the `clusterRef`-only manifest was accepted by
the API server.

Two prerequisites tripped me up and are worth recording for e2e coverage, neither related to
the reference: `Capability` also requires a role (the generated validation rejects a manifest
with neither `roleARN` nor `roleRef`), that role's trust policy must name
`capabilities.eks.amazonaws.com` with `sts:AssumeRole` **and** `sts:TagSession`, and the target
cluster's `accessConfig.authenticationMode` must be `API` or `API_AND_CONFIG_MAP`.

### What was checked mechanically

- Workspace refreshed (runtime, code-generator, controller) before generating; regenerated with `ack-workspace build eks` against code-generator `v0.62.1`.
- A `*Ref` companion is emitted on the spec for every field above.
- `resolveReferenceFor<Field>` is emitted for every field above, confirmed by diffing the *set* of resolver names against `main` (regeneration reorders the file, so a naive line diff over-reports).
- Fields that were in a CRD `required` list are relaxed out of it.
- `service_name` omitted for same-service targets, set for cross-service.
- `go build ./cmd/controller` passes.
- No new `go.mod` dependency, so `ATTRIBUTION.md` is unchanged.

### Commit layout

`main` now carries the code-generator `v0.62.1` regeneration (from the auto-generated release PR), and this branch is merged up to date with it, so the **Files changed** diff is limited to the reference change itself plus the recorded ack-generate stamp. The earlier regeneration commit on this branch is therefore redundant with main and contributes nothing to the diff.